### PR TITLE
pb/cg compat

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -104,3 +104,4 @@ tests:
     dependencies:
       - hspec
       - stackctl
+      - yaml

--- a/src/Stackctl/Spec/Discover.hs
+++ b/src/Stackctl/Spec/Discover.hs
@@ -31,9 +31,9 @@ discoverSpecs = do
   dir <- view directoryOptionL
   accountId <- fetchCurrentAccountId
   region <- fetchCurrentRegion
-  discovered <-
-    globRelativeTo dir
-    $ compile
+  discovered <- globRelativeTo
+    dir
+    [ compile
     $ "stacks"
     </> unpack (unAccountId accountId)
     <> ".*"
@@ -41,6 +41,15 @@ discoverSpecs = do
     <> "**"
     </> "*"
     <.> "yaml"
+    , compile
+    $ "stacks"
+    </> "*."
+    <> unpack (unAccountId accountId)
+    </> unpack (fromRegion region)
+    <> "**"
+    </> "*"
+    <.> "yaml"
+    ]
 
   filterOption <- view filterOptionL
 
@@ -133,6 +142,6 @@ fetchCurrentRegion
   => m Region
 fetchCurrentRegion = awsEc2DescribeFirstAvailabilityZoneRegionName
 
-globRelativeTo :: MonadIO m => FilePath -> Pattern -> m [FilePath]
-globRelativeTo dir p = liftIO $ do
-  map (dropWhile isPathSeparator . dropPrefix dir) <$> globDir1 p dir
+globRelativeTo :: MonadIO m => FilePath -> [Pattern] -> m [FilePath]
+globRelativeTo dir ps = liftIO $ do
+  map (dropWhile isPathSeparator . dropPrefix dir) . concat <$> globDir ps dir

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -107,14 +107,17 @@ writeStackSpec parent stackSpec@StackSpec {..} templateBody = do
 
 readStackSpec :: MonadIO m => FilePath -> StackSpecPath -> m StackSpec
 readStackSpec dir specPath = do
-  specBody <-
-    liftIO $ Yaml.decodeFileThrow $ dir </> stackSpecPathFilePath specPath
+  specBody <- liftIO $ either err pure =<< Yaml.decodeFileEither path
 
   pure StackSpec
     { ssSpecRoot = dir
     , ssSpecPath = specPath
     , ssSpecBody = specBody
     }
+ where
+  path = dir </> stackSpecPathFilePath specPath
+  err e =
+    throwString $ path <> " is invalid: " <> Yaml.prettyPrintParseException e
 
 -- | Create a Change Set between a Stack Specification and deployed state
 --

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -49,8 +49,9 @@ newtype ParameterYaml = ParameterYaml
   }
 
 instance FromJSON ParameterYaml where
-  parseJSON = withObject "Parameter"
-    $ \o -> build <$> o .: "ParameterKey" <*> o .: "ParameterValue"
+  parseJSON = withObject "Parameter" $ \o ->
+    (build <$> o .: "Name" <*> o .: "Value")
+      <|> (build <$> o .: "ParameterKey" <*> o .: "ParameterValue")
    where
     build k v = ParameterYaml $ makeParameter k $ Just $ unParameterValue v
 

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -163,6 +163,7 @@ test-suite spec
       Stackctl.AWS.CloudFormationSpec
       Stackctl.FilterOptionSpec
       Stackctl.StackSpecSpec
+      Stackctl.StackSpecYamlSpec
       Paths_stackctl
   hs-source-dirs:
       test
@@ -197,4 +198,5 @@ test-suite spec
       base ==4.*
     , hspec
     , stackctl
+    , yaml
   default-language: Haskell2010

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -61,3 +61,15 @@ spec = do
 
       show ex
         `shouldBe` "AesonException \"Error in $.Parameters[0].ParameterValue: Expected String or Number, got: Bool False\""
+
+    it "also accepts CloudGenesis formatted values" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
+        [ "Template: foo.yaml\n"
+        , "Parameters:\n"
+        , "  - Name: Foo\n"
+        , "    Value: Bar\n"
+        ]
+
+      let Just [ParameterYaml param] = ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Foo"
+      param ^. parameter_parameterValue `shouldBe` Just "Bar"

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -1,0 +1,63 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Stackctl.StackSpecYamlSpec
+  ( spec
+  ) where
+
+import Stackctl.Prelude
+
+import qualified Data.Yaml as Yaml
+import Stackctl.AWS
+import Stackctl.StackSpecYaml
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "decoding Yaml" $ do
+    it "reads String parameters" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
+        [ "Template: foo.yaml\n"
+        , "Parameters:\n"
+        , "  - ParameterKey: Foo\n"
+        , "    ParameterValue: Bar\n"
+        ]
+
+      let Just [ParameterYaml param] = ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Foo"
+      param ^. parameter_parameterValue `shouldBe` Just "Bar"
+
+    it "reads Number parameters without decimals" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
+        [ "Template: foo.yaml\n"
+        , "Parameters:\n"
+        , "  - ParameterKey: Port\n"
+        , "    ParameterValue: 80\n"
+        ]
+
+      let Just [ParameterYaml param] = ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Port"
+      param ^. parameter_parameterValue `shouldBe` Just "80"
+
+    it "reads Number parameters with decimals" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
+        [ "Template: foo.yaml\n"
+        , "Parameters:\n"
+        , "  - ParameterKey: Pie\n"
+        , "    ParameterValue: 3.14\n"
+        ]
+
+      let Just [ParameterYaml param] = ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Pie"
+      param ^. parameter_parameterValue `shouldBe` Just "3.14"
+
+    it "has informative errors" $ do
+      let
+        Left ex = Yaml.decodeEither' @StackSpecYaml $ mconcat
+          [ "Template: foo.yaml\n"
+          , "Parameters:\n"
+          , "  - ParameterKey: Norway\n"
+          , "    ParameterValue: no\n"
+          ]
+
+      show ex
+        `shouldBe` "AesonException \"Error in $.Parameters[0].ParameterValue: Expected String or Number, got: Bool False\""


### PR DESCRIPTION
- Support Numeric parameters in StackSpecYaml
- Support CloudGenesis-style Parameters
- Include path when unable to read a StackSpecYaml
- Work with /id.name/ or /name.id/ account paths
- fixup! Support Numeric parameters in StackSpecYaml
