### PR TITLE
Stackctl.Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           stack-arguments: --copy-bins
 
-      - uses: freckle/weeder-action@v1
-        with:
-          weeder-version: 2.3.0
-
       - uses: actions/upload-artifact@v2
         with:
           name: stackctl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.0.1.2...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.0.2.0...main)
+
+## [v1.0.2.0](https://github.com/freckle/stackctl/compare/v1.0.1.2...v1.0.2.0)
+
+- Add `Stackctl.Action`
+
+  Support for taking actions during Stack management, currently we support
+  invoking a lambda post-deployment. In the future, we can add more, such as
+  running local pre-deploy validation or preparation scripts.
+
+- Add `awsCloudFormationDescribeStackOutputs`
 
 ## [v1.0.1.2](https://github.com/freckle/stackctl/compare/v1.0.1.1...v1.0.1.2)
 

--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -97,6 +97,11 @@ Template: <path>
 Depends:
   - <name>
 
+Actions:
+  - on: <event>
+    run:
+      <action>: <argument...>
+
 Parameters:
   - ParameterKey: <string>
     ParameterValue: <string>
@@ -120,6 +125,24 @@ And these constituent parts are used as follows:
 
 > Optional. Other Stacks (by name) that should be ordered before this one if
 > deployed together.
+
+*{.Actions}*\
+
+> Optional. Actions to run when certain Stack management events occur.
+
+*{.Actions[].on}*\
+
+> The event on which to perform the action:
+>
+> - **PostDeploy**: run the action after a successful deployment
+
+*{.Actions[].run}*\
+
+> The action to perform on the given event:
+>
+> - **InvokeLambdaByStackOutput**: *\<output name>*: invoke the function whose
+>   name is found in the given Output of the deployed Stack
+> - **InvokeLambdaByName**: *\<function name>*: invoke the given function
 
 *{.Parameters}*\
 

--- a/package.yaml
+++ b/package.yaml
@@ -65,6 +65,7 @@ library:
     - amazonka-cloudformation
     - amazonka-core
     - amazonka-ec2
+    - amazonka-lambda
     - amazonka-sts
     - bytestring
     - cfn-flip

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.0.1.2
+version: 1.0.2.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/AWS/CloudFormation.hs
+++ b/src/Stackctl/AWS/CloudFormation.hs
@@ -33,6 +33,7 @@ module Stackctl.AWS.CloudFormation
   , output_outputValue
   , awsCloudFormationDescribeStack
   , awsCloudFormationDescribeStackMaybe
+  , awsCloudFormationDescribeStackOutputs
   , awsCloudFormationDescribeStackEvents
   , awsCloudFormationGetMostRecentStackEventId
   , awsCloudFormationDeleteStack
@@ -179,6 +180,14 @@ awsCloudFormationDescribeStackMaybe stackName =
   -- returning an empty list, so we need to do this through exceptions
   handling_ _ValidationError (pure Nothing) $ do
     Just <$> awsCloudFormationDescribeStack stackName
+
+awsCloudFormationDescribeStackOutputs
+  :: (MonadResource m, MonadReader env m, HasAwsEnv env)
+  => StackName
+  -> m [Output]
+awsCloudFormationDescribeStackOutputs stackName = do
+  stack <- awsCloudFormationDescribeStack stackName
+  pure $ fromMaybe [] $ outputs stack
 
 awsCloudFormationDescribeStackEvents
   :: (MonadResource m, MonadReader env m, HasAwsEnv env)

--- a/src/Stackctl/AWS/Lambda.hs
+++ b/src/Stackctl/AWS/Lambda.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE MultiWayIf #-}
+
+module Stackctl.AWS.Lambda
+  ( LambdaInvokeResult(..)
+  , LambdaError(..)
+  , logLambdaInvocationResult
+  , isLambdaInvocationSuccess
+  , awsLambdaInvoke
+  ) where
+
+import Stackctl.Prelude hiding (trace)
+
+import Amazonka.Lambda.Invoke
+import Data.Aeson
+import qualified Data.ByteString.Lazy as BSL
+import Stackctl.AWS.Core
+
+data LambdaInvokeResult
+  = LambdaInvokeSuccess
+  | LambdaInvokeError LambdaError (Maybe Text)
+  | LambdaInvokeFailure Int (Maybe Text)
+  deriving stock Show
+
+logLambdaInvocationResult :: MonadLogger m => LambdaInvokeResult -> m ()
+logLambdaInvocationResult = \case
+  LambdaInvokeSuccess -> logInfo "LambdaInvokeSuccess"
+  LambdaInvokeError LambdaError {..} mFunctionError ->
+    logError $ (:# []) $ mconcat
+      [ "LambdaInvokeError"
+      , "\n  errorType: " <> errorType
+      , "\n  errorMessage: " <> errorMessage
+      , "\n  trace: "
+      , mconcat $ map ("\n    " <>) trace
+      , "\n  FunctionError: " <> fromMaybe "none" mFunctionError
+      ]
+  LambdaInvokeFailure status mFunctionError -> logError $ (:# []) $ mconcat
+    [ "LambdaInvokeFailure"
+    , "\n  StatusCode: " <> pack (show status)
+    , "\n  FunctionError: " <> fromMaybe "none" mFunctionError
+    ]
+
+isLambdaInvocationSuccess :: LambdaInvokeResult -> Bool
+isLambdaInvocationSuccess = \case
+  LambdaInvokeSuccess -> True
+  LambdaInvokeError{} -> False
+  LambdaInvokeFailure{} -> False
+
+data LambdaError = LambdaError
+  { errorType :: Text
+  , errorMessage :: Text
+  , trace :: [Text]
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+awsLambdaInvoke
+  :: ( MonadResource m
+     , MonadLogger m
+     , MonadReader env m
+     , HasAwsEnv env
+     , ToJSON a
+     )
+  => Text
+  -> a -- ^ Payload
+  -> m LambdaInvokeResult
+awsLambdaInvoke name payload = do
+  logDebug $ "Invoking function" :# ["name" .= name]
+
+  resp <- awsSend $ newInvoke name $ BSL.toStrict $ encode payload
+
+  let
+    status = resp ^. invokeResponse_statusCode
+    mError = decode . BSL.fromStrict =<< resp ^. invokeResponse_payload
+    mFunctionError = resp ^. invokeResponse_functionError
+
+  logDebug
+    $ "Function result"
+    :# [ "name" .= name
+       , "status" .= status
+       , "error" .= mError
+       , "functionError" .= mFunctionError
+       ]
+
+  pure $ if
+    | statusIsUnsuccessful status -> LambdaInvokeFailure status mFunctionError
+    | Just e <- mError            -> LambdaInvokeError e mFunctionError
+    | otherwise                   -> LambdaInvokeSuccess
+
+statusIsUnsuccessful :: Int -> Bool
+statusIsUnsuccessful s = s < 200 || s >= 300

--- a/src/Stackctl/Action.hs
+++ b/src/Stackctl/Action.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Actions that can be performed on certain Stack management events
+--
+-- For example, to invoke a Lambda whose name is found in the deploying Stack's
+-- outputs after it's been deployed:
+--
+-- @
+-- Actions:
+--   - on: PostDeploy
+--     run:
+--       InvokeLambdaByStackOutput: OnDeployFunction
+-- @
+--
+module Stackctl.Action
+  ( Action
+  , newAction
+  , ActionOn(..)
+  , ActionRun(..)
+  , runActions
+  ) where
+
+import Stackctl.Prelude hiding (on)
+
+import Data.Aeson
+import Data.List (find)
+import Stackctl.AWS
+import Stackctl.AWS.Lambda
+
+data Action = Action
+  { on :: ActionOn
+  , run :: ActionRun
+  }
+  deriving stock Generic
+  deriving anyclass (FromJSON, ToJSON)
+
+newAction :: ActionOn -> ActionRun -> Action
+newAction = Action
+
+data ActionOn = PostDeploy
+  deriving stock (Eq, Generic)
+
+instance FromJSON ActionOn where
+  parseJSON = withText "ActionOn" $ \case
+    "PostDeploy" -> pure PostDeploy
+    x ->
+      fail $ "Invalid ActionOn: " <> show x <> ", must be one of [PostDeploy]"
+
+instance ToJSON ActionOn where
+  toJSON = \case
+    PostDeploy -> toJSON @Text "PostDeploy"
+  toEncoding = \case
+    PostDeploy -> toEncoding @Text "PostDeploy"
+
+data ActionRun
+  = InvokeLambdaByStackOutput Text
+  | InvokeLambdaByName Text
+
+instance FromJSON ActionRun where
+  parseJSON = withObject "ActionRun" $ \o -> asum
+    [ InvokeLambdaByStackOutput <$> o .: "InvokeLambdaByStackOutput"
+    , InvokeLambdaByStackOutput <$> o .: "InvokeLambdaByName"
+    ]
+
+instance ToJSON ActionRun where
+  toJSON = object . \case
+    InvokeLambdaByStackOutput name -> ["InvokeLambdaByStackOutput" .= name]
+    InvokeLambdaByName name -> ["InvokeLambdaByName" .= name]
+  toEncoding = pairs . \case
+    InvokeLambdaByStackOutput name -> "InvokeLambdaByStackOutput" .= name
+    InvokeLambdaByName name -> "InvokeLambdaByName" .= name
+
+data ActionFailure
+  = NoSuchOutput StackName Text [Output]
+  | InvokeLambdaFailure LambdaInvokeResult
+  deriving stock Show
+  deriving anyclass Exception
+
+runActions
+  :: (MonadResource m, MonadLogger m, MonadReader env m, HasAwsEnv env)
+  => StackName
+  -> ActionOn
+  -> [Action]
+  -> m ()
+runActions stackName on =
+  traverse_ (runAction stackName) . filter (`shouldRunOn` on)
+
+shouldRunOn :: Action -> ActionOn -> Bool
+shouldRunOn Action { on } on' = on == on'
+
+runAction
+  :: (MonadResource m, MonadLogger m, MonadReader env m, HasAwsEnv env)
+  => StackName
+  -> Action
+  -> m ()
+runAction stackName Action { on, run } = do
+  logInfo $ "Running action" :# ["on" .= on, "run" .= run]
+
+  case run of
+    InvokeLambdaByStackOutput outputName -> do
+      outputs <- awsCloudFormationDescribeStackOutputs stackName
+      case findOutputValue outputName outputs of
+        Nothing -> throwIO $ NoSuchOutput stackName outputName outputs
+        Just name -> invoke name
+    InvokeLambdaByName name -> invoke name
+ where
+  invoke name = do
+    result <- awsLambdaInvoke name payload
+    logLambdaInvocationResult result
+    unless (isLambdaInvocationSuccess result) $ throwIO $ InvokeLambdaFailure
+      result
+
+  payload = object ["stack" .= stackName, "event" .= on]
+
+findOutputValue :: Text -> [Output] -> Maybe Text
+findOutputValue name =
+  view output_outputValue <=< find ((== Just name) . view output_outputKey)

--- a/src/Stackctl/Spec/Capture.hs
+++ b/src/Stackctl/Spec/Capture.hs
@@ -79,6 +79,7 @@ runCapture CaptureOptions {..} = do
     , gStackPath = scoStackPath
     , gStackName = scoStackName
     , gDepends = scoDepends
+    , gActions = Nothing
     , gParameters = parameters stack
     , gCapabilities = capabilities stack
     , gTags = tags stack

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -14,6 +14,7 @@ import Data.Time (defaultTimeLocale, formatTime, utcToLocalZonedTime)
 import Options.Applicative
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Action
 import Stackctl.Colors
 import Stackctl.DirectoryOption (HasDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption)
@@ -86,6 +87,7 @@ runDeploy DeployOptions {..} = do
             writeFileUtf8 out $ changeSetJSON changeSet
 
           deployChangeSet sdoDeployConfirmation changeSet
+          runActions stackName PostDeploy $ stackSpecActions spec
           when sdoClean $ awsCloudFormationDeleteAllChangeSets stackName
 
 data DeployConfirmation

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -8,6 +8,7 @@ import Stackctl.Prelude
 import Data.Aeson
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Action
 import Stackctl.Spec.Discover (buildSpecPath)
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath
@@ -21,6 +22,7 @@ data Generate = Generate
   -- ^ If not given will use @{stack-name}.yaml@
   , gStackName :: StackName
   , gDepends :: Maybe [StackName]
+  , gActions :: Maybe [Action]
   , gParameters :: Maybe [Parameter]
   , gCapabilities :: Maybe [Capability]
   , gTags :: Maybe [Tag]
@@ -48,6 +50,7 @@ generate Generate {..} = do
     specYaml = StackSpecYaml
       { ssyTemplate = templatePath
       , ssyDepends = gDepends
+      , ssyActions = gActions
       , ssyParameters = map ParameterYaml <$> gParameters
       , ssyCapabilities = gCapabilities
       , ssyTags = map TagYaml <$> gTags

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -3,6 +3,7 @@ module Stackctl.StackSpec
   , stackSpecSpecPath
   , stackSpecSpecBody
   , stackSpecStackName
+  , stackSpecActions
   , stackSpecParameters
   , stackSpecCapabilities
   , stackSpecTags
@@ -20,6 +21,7 @@ import Data.Aeson
 import Data.Graph (graphFromEdges, topSort)
 import qualified Data.Yaml as Yaml
 import Stackctl.AWS
+import Stackctl.Action
 import Stackctl.StackSpecPath
 import Stackctl.StackSpecYaml
 import UnliftIO.Directory (createDirectoryIfMissing)
@@ -41,6 +43,9 @@ stackSpecStackName = stackSpecPathStackName . ssSpecPath
 
 stackSpecDepends :: StackSpec -> [StackName]
 stackSpecDepends = fromMaybe [] . ssyDepends . ssSpecBody
+
+stackSpecActions :: StackSpec -> [Action]
+stackSpecActions = fromMaybe [] . ssyActions . ssSpecBody
 
 stackSpecTemplateFile :: StackSpec -> StackTemplate
 stackSpecTemplateFile StackSpec {..} =

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -30,10 +30,12 @@ import Data.Aeson
 import Data.Aeson.Casing
 import qualified Data.Text as T
 import Stackctl.AWS
+import Stackctl.Action
 
 data StackSpecYaml = StackSpecYaml
   { ssyTemplate :: FilePath
   , ssyDepends :: Maybe [StackName]
+  , ssyActions :: Maybe [Action]
   , ssyParameters :: Maybe [ParameterYaml]
   , ssyCapabilities :: Maybe [Capability]
   , ssyTags :: Maybe [TagYaml]

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -3,6 +3,9 @@
 -- @
 -- Template: <path>
 --
+-- Depends:
+-- - <string>
+--
 -- Parameters:
 -- - ParameterKey: <string>
 --   ParameterValue: <string>

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,3 @@ extra-deps:
       - lib/services/amazonka-lambda
       - lib/services/amazonka-sso
       - lib/services/amazonka-sts
-
-  # For weeder-2.3.0
-  - algebraic-graphs-0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,10 +13,11 @@ extra-deps:
     subdirs:
       - lib/amazonka
       - lib/amazonka-core
-      - lib/services/amazonka-cloudformation
       - lib/services/amazonka-certificatemanager
+      - lib/services/amazonka-cloudformation
       - lib/services/amazonka-ec2
       - lib/services/amazonka-ecr
+      - lib/services/amazonka-lambda
       - lib/services/amazonka-sso
       - lib/services/amazonka-sts
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -59,19 +59,6 @@ packages:
     subdir: lib/amazonka-core
     url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
 - completed:
-    name: amazonka-cloudformation
-    pantry-tree:
-      sha256: a9f557fdf3f3d5f960a28921465609e338ce702e1ecdf6e559e01efdccb364a6
-      size: 25784
-    sha256: 14aeaa9f748f7ac03683e8a8126760ed16aa82152404a96c0333b582444cd381
-    size: 27775608
-    subdir: lib/services/amazonka-cloudformation
-    url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
-    version: '2.0'
-  original:
-    subdir: lib/services/amazonka-cloudformation
-    url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
-- completed:
     name: amazonka-certificatemanager
     pantry-tree:
       sha256: 86c39ebac8e40030c05048385c1153deb124193e49bb2651c38bd1232bbd3fff
@@ -83,6 +70,19 @@ packages:
     version: '2.0'
   original:
     subdir: lib/services/amazonka-certificatemanager
+    url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
+- completed:
+    name: amazonka-cloudformation
+    pantry-tree:
+      sha256: a9f557fdf3f3d5f960a28921465609e338ce702e1ecdf6e559e01efdccb364a6
+      size: 25784
+    sha256: 14aeaa9f748f7ac03683e8a8126760ed16aa82152404a96c0333b582444cd381
+    size: 27775608
+    subdir: lib/services/amazonka-cloudformation
+    url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
+    version: '2.0'
+  original:
+    subdir: lib/services/amazonka-cloudformation
     url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
 - completed:
     name: amazonka-ec2
@@ -109,6 +109,19 @@ packages:
     version: '2.0'
   original:
     subdir: lib/services/amazonka-ecr
+    url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
+- completed:
+    name: amazonka-lambda
+    pantry-tree:
+      sha256: 7e6feb0f8af0a9f6ce20db04d69a0e7b92838f27d17f65f0cd1a3c87b6a6331e
+      size: 19117
+    sha256: 14aeaa9f748f7ac03683e8a8126760ed16aa82152404a96c0333b582444cd381
+    size: 27775608
+    subdir: lib/services/amazonka-lambda
+    url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
+    version: '2.0'
+  original:
+    subdir: lib/services/amazonka-lambda
     url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
 - completed:
     name: amazonka-sso

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -149,13 +149,6 @@ packages:
   original:
     subdir: lib/services/amazonka-sts
     url: https://github.com/brendanhay/amazonka/archive/f73a957d05f64863e867cf39d0db260718f0fadd.tar.gz
-- completed:
-    hackage: algebraic-graphs-0.5@sha256:6eeec5ed1687ff7aa916e7bf9f02f51aaabde6f314dc0b7b1a84156974d7da73,8071
-    pantry-tree:
-      sha256: cca4a0348bb126506cacd8436948a68aad62e75d45df8c71f4090a00e69b45ee
-      size: 4128
-  original:
-    hackage: algebraic-graphs-0.5
 snapshots:
 - completed:
     sha256: 7f4393ad659c579944d12202cffb12d8e4b8114566b015f77bbc303a24cff934

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.0.1.2
+version:        1.0.2.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -25,10 +25,12 @@ source-repository head
 
 library
   exposed-modules:
+      Stackctl.Action
       Stackctl.AWS
       Stackctl.AWS.CloudFormation
       Stackctl.AWS.Core
       Stackctl.AWS.EC2
+      Stackctl.AWS.Lambda
       Stackctl.AWS.Orphans
       Stackctl.AWS.Scope
       Stackctl.AWS.STS
@@ -96,6 +98,7 @@ library
     , amazonka-cloudformation
     , amazonka-core
     , amazonka-ec2
+    , amazonka-lambda
     , amazonka-sts
     , base ==4.*
     , bytestring

--- a/test/Stackctl/StackSpecSpec.hs
+++ b/test/Stackctl/StackSpecSpec.hs
@@ -33,6 +33,7 @@ toSpec name depends = buildStackSpec "." specPath specBody
   specPath = stackSpecPath scope stackName "a/b.yaml"
   specBody = StackSpecYaml
     { ssyDepends = Just $ map StackName depends
+    , ssyActions = Nothing
     , ssyTemplate = ""
     , ssyParameters = Nothing
     , ssyCapabilities = Nothing

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -1,4 +1,0 @@
-{ roots =
-  [ "^Main\\.main\$", "^Paths_.*", "^Stackctl\\.AWS\\.Core\\.awsWithin\$" ]
-, type-class-roots = True
-}


### PR DESCRIPTION
Adds an `Actions` key to the Stack Specification format.

For example,

```yaml
Actions:
  - on: PostDeploy
    run:
      InvokeLambdaByStackOutput: OnDeployFunction
```

This will look for the Output named `OnDeployFunction` and invoke it after deploying the given Stack.

This implements Option 3 from [this Stackoverflow](https://stackoverflow.com/questions/41350483/is-it-possible-to-trigger-a-lambda-on-creation-from-cloudformation-template/41388529#41388529).

## Why is this useful?

Right now, this is the only `on` and `run` we support, and it is useful to run a Lambda that copies assets from a shared app-version bucket to the "live" bucket on deployment. By putting this Lambda in the Stack itself, it has a convenient reference to the anonymous Bucket, its Policy, the CF Distribution to invalidate, etc. It also remains owned by the App team that owns the Stack.

We can extend this system in the future -- such as,

```yaml
on: PreDeploy
run:
  RunProcess:
    - ./scripts/quiet-and-wait
    - --timeout
    - 120
```

If we have a Stack that should "quiet and wait" before executing a deployment.

## What about SNS?

(Option 1 from the linked Stackoverflow.)

CloudFormation can be configured to emit to an SNS topic on events like create/update/etc. This is a _very good_ fit, but I chose not to do it for a few reasons:

- It requires the topic exist ahead of time, so we'd need another stack outside of the one who needs this
- You can't pass arbitrary data to the Lambda on the other side -- for example, when using this to deploy a static site we want to tell the Lambda the version of the code to deploy
- We can't extend this to the `RunProcess` example

It's possible we could accept point 1, work around point 2, and give up on point 3, if we feel using that more conventional approach is valuable.

## What about custom resources?

(Option 2 from the linked Stackoverflow.)

Another approach to this is to add a Custom Resource to your stack which represents the triggering of a Lambda when it is deployed. This requires a "service provider" establish an API to represent the resource and its actions, I chose not to do this because of that complexity.