### PR TITLE
Push stack-deploy events to the main Logger

### DIFF
--- a/doc/stackctl-changes.1.md
+++ b/doc/stackctl-changes.1.md
@@ -22,6 +22,14 @@ successful operation.
 
 > Output changes in **FORMAT**. See dedicated section.
 
+**PATH**\
+
+> Where to write the changes summary.
+>
+> This is a required option to make the interaction with logging explicit. You
+> can pass */dev/stdout* if you want the changes written alongside any logging
+> and don't mind interleaving or ordering problems that may occur.
+
 # AVAILABLE FORMATS
 
 **tty**\

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ library:
     - errors
     - exceptions
     - extra
+    - fast-logger
     - filepath
     - lens
     - lens-aeson

--- a/src/Stackctl/CLI.hs
+++ b/src/Stackctl/CLI.hs
@@ -75,10 +75,7 @@ runAppT
   -> AppT (App options) m a
   -> m a
 runAppT options f = do
-  -- Log to stderr by default, since we produce useful stdout (e.g. changes).
-  envLogSettings <- liftIO $ LoggingEnv.parseWith $ setLogSettingsDestination
-    LogDestinationStderr
-    defaultLogSettings
+  envLogSettings <- liftIO LoggingEnv.parse
 
   logger <- newLogger $ adjustLogSettings
     (options ^. colorOptionL)

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -46,8 +46,7 @@ capture = Subcommand
   }
 
 changes
-  :: ( HasLogger env
-     , HasAwsScope env
+  :: ( HasAwsScope env
      , HasAwsEnv env
      , HasDirectoryOption env
      , HasFilterOption env

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -108,6 +108,7 @@ library
     , errors
     , exceptions
     , extra
+    , fast-logger
     , filepath
     , lens
     , lens-aeson


### PR DESCRIPTION
[Add PATH argument to changes sub-command](https://github.com/freckle/stackctl/pull/10/commits/f995acef75351fafdfc61d8a3c308176d03e0446)

This is the only case of "useful" output we produce. Making its
destination explicit will free us up to simplify other outputs (logging
and stack-deployment events) to hopefully address the ordering issues we
see by the careful use of handles we needed to support the default
output for changes.

In our own use of the `changes` subcommand, we redirect it to a file
anyway, so this will even make that more convenient.

[Log to stdout by default](https://github.com/freckle/stackctl/pull/10/commits/c9507002593227cf25e4950160235e86ce333c8f)

Now that `changes` output is handled separately, we can go back to
defaults on this.

[Emit stack-deploy events through the main Logger](https://github.com/freckle/stackctl/pull/10/commits/168e06850df1bc281676058304ec5f9c3600f25d)

This should avoid any interleaving or ordering issues in the observed
output, by channeling everything through the same thing.