### PR TITLE
Update Blammo lower-bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.1.0.2...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.1.0.3...main)
+
+## [v1.1.0.3](https://github.com/freckle/stackctl/compare/v1.1.0.2...v1.1.0.3)
+
+- Require Blammo-1.1.1.0
 
 ## [v1.1.0.2](https://github.com/freckle/stackctl/compare/v1.1.0.1...v1.1.0.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -56,7 +56,7 @@ default-extensions:
 library:
   source-dirs: src
   dependencies:
-    - Blammo >= 1.1.0.0 # flushLogger
+    - Blammo >= 1.1.1.0 # flushLogger (compile), multiline (feature)
     - Glob
     - aeson
     - aeson-casing

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.1.0.2
+version: 1.1.0.3
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-19.31
 
 extra-deps:
-  - Blammo-1.1.0.0
+  - Blammo-1.1.1.0
   - cfn-flip-0.1.0.3
 
   # For Blammo

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: Blammo-1.1.0.0@sha256:6195c1e290c78ba2c454966b95ba486583592392e46e09f4da806c5fb97c4919,3897
+    hackage: Blammo-1.1.1.0@sha256:60d5fce5abe561b27389da1df6a17fefef36e91e956790f10626b5cf1a19cde3,4008
     pantry-tree:
-      sha256: a37b1b5974dcb28ea3405dac0ccd14f206c414e989aa52dd72bd0a83c1e890fc
-      size: 1258
+      sha256: 9dabb8c19abb6d1c60c5ebbfbf8960cc45b4db609d0559c06a8cd94cb513272b
+      size: 1415
   original:
-    hackage: Blammo-1.1.0.0
+    hackage: Blammo-1.1.1.0
 - completed:
     hackage: cfn-flip-0.1.0.3@sha256:8737882d818d74b29d3b1791a4df4dc89995870312374989c47c29352ea503ec,5615
     pantry-tree:

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.1.0.2
+version:        1.1.0.3
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -89,7 +89,7 @@ library
       TypeFamilies
   ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
-      Blammo >=1.1.0.0
+      Blammo >=1.1.1.0
     , Glob
     , aeson
     , aeson-casing


### PR DESCRIPTION
v1.1.1.0 brings an intelligent multiline terminal format that we'd like
to see in use everywhere.