### PR TITLE
Add completion actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       # Fix for "error while loading shared libraries: libtinfo.so.5: cannot
       # open shared object file: No such file or directory"
-      - run: apt install -y libncurses5
+      - run: sudo apt-get install -y libncurses5
 
       - uses: actions/checkout@v3
       - uses: haskell/actions/hlint-setup@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,8 @@ jobs:
   #     - run: cram -v integration/tests
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      # Fix for "error while loading shared libraries: libtinfo.so.5: cannot
-      # open shared object file: No such file or directory"
-      - run: sudo apt-get install -y libncurses5
-
       - uses: actions/checkout@v3
       - uses: haskell/actions/hlint-setup@v2
       - uses: haskell/actions/hlint-run@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      # Fix for "error while loading shared libraries: libtinfo.so.5: cannot
+      # open shared object file: No such file or directory"
+      - run: apt install -y libncurses5
+
       - uses: actions/checkout@v3
       - uses: haskell/actions/hlint-setup@v2
       - uses: haskell/actions/hlint-run@v2

--- a/src/Stackctl/DirectoryOption.hs
+++ b/src/Stackctl/DirectoryOption.hs
@@ -21,4 +21,5 @@ directoryOption = option str $ mconcat
   , help "Operate on specifications in PATH"
   , value "."
   , showDefault
+  , action "directory"
   ]

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -8,7 +8,7 @@ import Stackctl.Prelude
 
 import qualified Data.Text.IO as T
 import Options.Applicative
-import Stackctl.AWS
+import Stackctl.AWS hiding (action)
 import Stackctl.AWS.Scope
 import Stackctl.Colors
 import Stackctl.DirectoryOption (HasDirectoryOption)
@@ -31,6 +31,7 @@ runChangesOptions = ChangesOptions
   <*> argument str
     (  metavar "PATH"
     <> help "Where to write the changes summary"
+    <> action "file"
     )
 
 runChanges

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -11,7 +11,7 @@ import Blammo.Logging.Logger (pushLogStrLn)
 import qualified Data.Text as T
 import Data.Time (defaultTimeLocale, formatTime, utcToLocalZonedTime)
 import Options.Applicative
-import Stackctl.AWS
+import Stackctl.AWS hiding (action)
 import Stackctl.AWS.Scope
 import Stackctl.Action
 import Stackctl.Colors
@@ -38,6 +38,7 @@ runDeployOptions = DeployOptions
     (  long "save-change-sets"
     <> metavar "DIRECTORY"
     <> help "Save executed changesets to DIRECTORY"
+    <> action "directory"
     ))
   <*> flag DeployWithConfirmation DeployWithoutConfirmation
     (  long "no-confirm"


### PR DESCRIPTION
See https://github.com/pcapriotti/optparse-applicative/wiki/Bash-Completion#customizing-completions

Bash comes with built-in actions, including completing files or
directories. Let's use those where we can.

Some more we could do (but aren't yet):

- `capture -t` and `-p` could complete relative paths under `templates/`
  and `stacks/{account}/{region}` respectively
- `capture -d` could complete names of existing Stacks
