### PR TITLE
Add --parameter to changes and deploy

### DIFF
--- a/doc/stackctl-changes.1.md
+++ b/doc/stackctl-changes.1.md
@@ -22,6 +22,12 @@ successful operation.
 
 > Output changes in **FORMAT**. See dedicated section.
 
+**\-p**, **\--parameter** *\<KEY=[VALUE]\>*\
+
+> Override the given Parameter for this operation. Omitting *VALUE* will result
+> in overriding the Parameter as an empty string. May be specified 0 or more
+> times.
+
 **PATH**\
 
 > Where to write the changes summary.

--- a/doc/stackctl-deploy.1.md
+++ b/doc/stackctl-deploy.1.md
@@ -17,6 +17,12 @@ creates a Change Set and executes it after confirmation.
 
 # OPTIONS
 
+**\-p**, **\--parameter** *\<KEY=[VALUE]\>*\
+
+> Override the given Parameter for this operation. Omitting *VALUE* will result
+> in overriding the Parameter as an empty string. May be specified 0 or more
+> times.
+
 **\--save-change-sets** *\<PATH\>*\
 
 > Save generated Change Sets to **PATH/STACK.json**

--- a/src/Stackctl/ParameterOption.hs
+++ b/src/Stackctl/ParameterOption.hs
@@ -1,0 +1,25 @@
+module Stackctl.ParameterOption
+  ( parameterOption
+  ) where
+
+import Stackctl.Prelude
+
+import qualified Data.Text as T
+import Options.Applicative
+import Stackctl.AWS.CloudFormation (Parameter, makeParameter)
+
+parameterOption :: Parser Parameter
+parameterOption = option (eitherReader readParameter) $ mconcat
+  [ short 'p'
+  , long "parameter"
+  , metavar "KEY=[VALUE]"
+  , help "Override the given Parameter for this operation"
+  ]
+
+readParameter :: String -> Either String Parameter
+readParameter s = case T.breakOn "=" t of
+  (_, v) | T.null v -> Left $ "No '=' found (" <> s <> ")"
+  (k, _) | T.null k -> Left $ "Empty key (" <> s <> ")"
+  (k, "=") -> Right $ makeParameter k $ Just ""
+  (k, v) -> Right $ makeParameter k $ Just $ T.drop 1 v
+  where t = pack s

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -13,6 +13,7 @@ import Stackctl.AWS.Scope
 import Stackctl.Colors
 import Stackctl.DirectoryOption (HasDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption)
+import Stackctl.ParameterOption
 import Stackctl.Spec.Changes.Format
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
@@ -20,6 +21,7 @@ import Stackctl.StackSpecPath
 
 data ChangesOptions = ChangesOptions
   { scoFormat :: Format
+  , scoParameters :: [Parameter]
   , scoOutput :: FilePath
   }
 
@@ -28,6 +30,7 @@ data ChangesOptions = ChangesOptions
 runChangesOptions :: Parser ChangesOptions
 runChangesOptions = ChangesOptions
   <$> formatOption
+  <*> many parameterOption
   <*> argument str
     (  metavar "PATH"
     <> help "Where to write the changes summary"
@@ -56,7 +59,7 @@ runChanges ChangesOptions {..} = do
 
   for_ specs $ \spec -> do
     withThreadContext ["stackName" .= stackSpecStackName spec] $ do
-      emChangeSet <- createChangeSet spec
+      emChangeSet <- createChangeSet spec scoParameters
 
       case emChangeSet of
         Left err -> do

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -41,6 +41,7 @@ library
       Stackctl.DirectoryOption
       Stackctl.FilterOption
       Stackctl.Options
+      Stackctl.ParameterOption
       Stackctl.Prelude
       Stackctl.Prompt
       Stackctl.Spec.Capture


### PR DESCRIPTION
We originally did not have this because the expectation is that you are
always reviewing, committing, and automatically-executing things from
the on-disk representation.

However, RDS upgrades (as one example) require a few manual deployments
with different parameters. Being able to pass an override for one of the
deploys is better than having to deploy-edit-deploy-edit-deploy,
particularly when you're trying to script the whole cycle.
