### PR TITLE
Sort resource changes by causing entity

### DIFF
--- a/src/Stackctl/AWS/CloudFormation.hs
+++ b/src/Stackctl/AWS/CloudFormation.hs
@@ -404,7 +404,7 @@ changeCausedBy c = fromMaybe [] $ do
 
 detailCausingLogicalResourceId :: ResourceChangeDetail -> Maybe Text
 detailCausingLogicalResourceId ResourceChangeDetail' {..} =
-      T.takeWhile (/= '.') <$> causingEntity
+  T.takeWhile (/= '.') <$> causingEntity
 
 awsCloudFormationExecuteChangeSet
   :: (MonadResource m, MonadReader env m, HasAwsEnv env) => ChangeSetId -> m ()

--- a/src/Stackctl/Sort.hs
+++ b/src/Stackctl/Sort.hs
@@ -1,0 +1,26 @@
+module Stackctl.Sort
+  ( sortByDependencies
+  ) where
+
+import Stackctl.Prelude
+
+import Data.Graph (graphFromEdges, topSort)
+
+sortByDependencies
+  :: Ord k
+  => (a -> k)
+  -- ^ How to identify a given item
+  -> (a -> [k])
+  -- ^ How to get the given item's dependencies
+  -> [a]
+  -> [a]
+sortByDependencies toName toDepends specs =
+  map nodeFromVertex $ reverse $ topSort graph
+ where
+  (graph, tripleFromVertex, _) = graphFromEdges $ map tripleFromNode specs
+
+  nodeFromVertex = nodeFromTriple . tripleFromVertex
+
+  tripleFromNode n = (n, toName n, toDepends n)
+
+  nodeFromTriple (n, _, _) = n

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -18,11 +18,11 @@ import Stackctl.Prelude
 
 import qualified CfnFlip
 import Data.Aeson
-import Data.Graph (graphFromEdges, topSort)
 import Data.List.Extra (nubOrdOn)
 import qualified Data.Yaml as Yaml
 import Stackctl.AWS
 import Stackctl.Action
+import Stackctl.Sort
 import Stackctl.StackSpecPath
 import Stackctl.StackSpecYaml
 import UnliftIO.Directory (createDirectoryIfMissing)
@@ -119,12 +119,4 @@ createChangeSet spec parameters = awsCloudFormationCreateChangeSet
   (stackSpecTags spec)
 
 sortStackSpecs :: [StackSpec] -> [StackSpec]
-sortStackSpecs specs = map nodeFromVertex $ reverse $ topSort graph
- where
-  (graph, tripleFromVertex, _) = graphFromEdges $ map tripleFromNode specs
-
-  nodeFromVertex = nodeFromTriple . tripleFromVertex
-
-  tripleFromNode n = (n, stackSpecStackName n, stackSpecDepends n)
-
-  nodeFromTriple (n, _, _) = n
+sortStackSpecs = sortByDependencies stackSpecStackName stackSpecDepends

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -44,6 +44,7 @@ library
       Stackctl.ParameterOption
       Stackctl.Prelude
       Stackctl.Prompt
+      Stackctl.Sort
       Stackctl.Spec.Capture
       Stackctl.Spec.Cat
       Stackctl.Spec.Changes


### PR DESCRIPTION
- [Extract Stackctl.Sort](https://github.com/freckle/stackctl/pull/17/commits/2f24e1f27e0609e271fa5a10c3d73215d8ed6025)

  We're going to do this elsewhere, so we need it centralized.

- [Sort resource changes by causing entity](https://github.com/freckle/stackctl/pull/17/commits/5c2557151bfcf0ea8e2fe6285d9b9bc649cb0ec0)

  This will list resources before any others where they are the "caused
  by". This should make the list easiest to understand when changes cause
  other changes.