### PR TITLE
Support special values for changes destination

### DIFF
--- a/doc/stackctl-changes.1.md
+++ b/doc/stackctl-changes.1.md
@@ -32,9 +32,16 @@ successful operation.
 
 > Where to write the changes summary.
 >
-> This is a required option to make the interaction with logging explicit. You
-> can pass */dev/stdout* if you want the changes written alongside any logging
-> and don't mind interleaving or ordering problems that may occur.
+> This is a required option to make the interaction with logging explicit. In
+> addition to a filepath, this option recognizes three special values:
+>
+> - **-**: send the changes to *stdout*. This can be useful if you want to pipe
+>   the output somewhere and are either OK with interleaved logging output, or
+>   have worked around it somehow (such as configuring logging to *stderr*)
+> - **@log**, **@logger**: send the changes in the stream alongside other
+>   logging. This is useful if you just want to view the changes and not capture
+>   or process them. Using **@log** instead of **-** will keep things correctly
+>   ordered and prevent interleaving.
 
 # AVAILABLE FORMATS
 

--- a/package.yaml
+++ b/package.yaml
@@ -16,6 +16,7 @@ dependencies:
   - base >= 4 && < 5
 
 ghc-options:
+  - -fignore-optim-changes
   - -fwrite-ide-info
   - -Weverything
   - -Wno-all-missed-specialisations

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -46,7 +46,8 @@ capture = Subcommand
   }
 
 changes
-  :: ( HasAwsScope env
+  :: ( HasLogger env
+     , HasAwsScope env
      , HasAwsEnv env
      , HasDirectoryOption env
      , HasFilterOption env

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -89,7 +89,7 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
+  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       Blammo >=1.1.1.0
     , Glob
@@ -159,7 +159,7 @@ executable stackctl
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base ==4.*
     , stackctl
@@ -202,7 +202,7 @@ test-suite spec
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
+  ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       base ==4.*
     , hspec


### PR DESCRIPTION
Working in TTY and wanting to just see the changes is valuable, having
it go the logger is required for it to be ordered correctly in such a
case, but not a useful default. It's pretty easy (albeit perhaps not
particularly discoverable) to support that.
