### PR TITLE
Add --no-flip to stackctl-capture

### DIFF
--- a/doc/stackctl-capture.1.md
+++ b/doc/stackctl-capture.1.md
@@ -33,6 +33,11 @@ If files already exist at the inferred locations, they will be overwritten.
 
 > Relative path for specification. Default is **${STACK}.yaml**.
 
+**\--no-flip**\
+
+> Don't flip JSON templates to Yaml. This option is ignored if the template is
+> not JSON.
+
 **STACK**\
 
 > Name of Stack to capture.

--- a/src/Stackctl/Spec/Capture.hs
+++ b/src/Stackctl/Spec/Capture.hs
@@ -11,12 +11,14 @@ import Stackctl.AWS
 import Stackctl.AWS.Scope
 import Stackctl.DirectoryOption (HasDirectoryOption(..))
 import Stackctl.Spec.Generate
+import Stackctl.StackSpec
 
 data CaptureOptions = CaptureOptions
   { scoAccountName :: Maybe Text
   , scoTemplatePath :: Maybe FilePath
   , scoStackPath :: Maybe FilePath
   , scoDepends :: Maybe [StackName]
+  , scoTemplateFormat :: TemplateFormat
   , scoStackName :: StackName
   }
 
@@ -47,6 +49,10 @@ runCaptureOptions = CaptureOptions
       <> metavar "STACK"
       <> help "Add a dependency on STACK"
       )))
+    <*> flag TemplateFormatYaml TemplateFormatJson
+      (  long "no-flip"
+      <> help "Don't flip JSON templates to Yaml"
+      )
     <*> (StackName <$> argument str
       (  metavar "STACK"
       <> help "Name of deployed Stack to capture"
@@ -76,6 +82,7 @@ runCapture CaptureOptions {..} = do
   void $ local (awsScopeL %~ setScopeName) $ generate Generate
     { gOutputDirectory = dir
     , gTemplatePath = scoTemplatePath
+    , gTemplateFormat = scoTemplateFormat
     , gStackPath = scoStackPath
     , gStackName = scoStackName
     , gDepends = scoDepends
@@ -83,5 +90,5 @@ runCapture CaptureOptions {..} = do
     , gParameters = parameters stack
     , gCapabilities = capabilities stack
     , gTags = tags stack
-    , gTemplate = template
+    , gTemplateBody = templateBodyFromValue template
     }


### PR DESCRIPTION
Sometimes we are capturing legacy templates with JSON bodies in an
attempt to move from old to new (Stackctl-based) tooling. If we flip
these to Yaml, CloudFormation often infers spurious changes that makes
it riskier to proceed with the capture. Keeping them JSON avoids this
and lets us tackle flipping to Yaml later while still getting over to
the new tooling now.

Without this, I've been using `capture` then manually copying in the
JSON and renaming the file. This is annoying and error-prone.

I debating calling the flag `--no-flip-yaml`, as in "Don't flip to
Yaml", but then I thought `--no-flip-json`, as in "Don't flip from JSON"
could be equally reasonable. So I went with being _more_ vague in hopes
the user will check the docs if they're unsure.
