### PR TITLE
Make PATH optional to stackctl-changes 

### DIFF
--- a/doc/stackctl-changes.1.md
+++ b/doc/stackctl-changes.1.md
@@ -30,11 +30,7 @@ successful operation.
 
 **PATH**\
 
-> Where to write the changes summary.
->
-> This is a required option to make the interaction with logging explicit. You
-> can pass */dev/stdout* if you want the changes written alongside any logging
-> and don't mind interleaving or ordering problems that may occur.
+> Write changes to **PATH**, instead of printing them.
 
 # AVAILABLE FORMATS
 

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -46,7 +46,8 @@ capture = Subcommand
   }
 
 changes
-  :: ( HasAwsScope env
+  :: ( HasLogger env
+     , HasAwsScope env
      , HasAwsEnv env
      , HasDirectoryOption env
      , HasFilterOption env

--- a/src/Stackctl/Logger.hs
+++ b/src/Stackctl/Logger.hs
@@ -1,0 +1,14 @@
+module Stackctl.Logger
+  ( flushLogger
+  , pushLogger
+  ) where
+
+import Stackctl.Prelude
+
+import Blammo.Logging.Logger (flushLogger, pushLogStrLn)
+import System.Log.FastLogger (toLogStr)
+
+pushLogger :: (MonadIO m, MonadReader env m, HasLogger env) => Text -> m ()
+pushLogger msg = do
+  logger <- view loggerL
+  pushLogStrLn logger $ toLogStr msg

--- a/src/Stackctl/Prompt.hs
+++ b/src/Stackctl/Prompt.hs
@@ -5,9 +5,9 @@ module Stackctl.Prompt
 
 import Stackctl.Prelude
 
-import Blammo.Logging.Logger (flushLogger)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Stackctl.Logger
 
 prompt
   :: (MonadIO m, MonadLogger m, MonadReader env m, HasLogger env)

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -6,7 +6,6 @@ module Stackctl.Spec.Cat
 
 import Stackctl.Prelude
 
-import Blammo.Logging.Logger (flushLogger)
 import Data.Aeson
 import Data.Aeson.Lens
 import qualified Data.HashMap.Strict as HashMap
@@ -21,6 +20,7 @@ import Stackctl.AWS.Scope
 import Stackctl.Colors
 import Stackctl.DirectoryOption (HasDirectoryOption(..))
 import Stackctl.FilterOption (HasFilterOption)
+import Stackctl.Logger
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -7,7 +7,6 @@ module Stackctl.Spec.Deploy
 
 import Stackctl.Prelude
 
-import Blammo.Logging.Logger (pushLogStrLn)
 import qualified Data.Text as T
 import Data.Time (defaultTimeLocale, formatTime, utcToLocalZonedTime)
 import Options.Applicative
@@ -17,12 +16,12 @@ import Stackctl.Action
 import Stackctl.Colors
 import Stackctl.DirectoryOption (HasDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption)
+import Stackctl.Logger
 import Stackctl.ParameterOption
 import Stackctl.Prompt
 import Stackctl.Spec.Changes.Format
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
-import System.Log.FastLogger (toLogStr)
 import UnliftIO.Directory (createDirectoryIfMissing)
 
 data DeployOptions = DeployOptions
@@ -229,8 +228,3 @@ formatStackEvent Colors {..} e = do
 
 getLastEventId :: [StackEvent] -> Maybe Text
 getLastEventId = fmap (^. stackEvent_eventId) . listToMaybe
-
-pushLogger :: (MonadIO m, MonadReader env m, HasLogger env) => Text -> m ()
-pushLogger msg = do
-  logger <- view loggerL
-  pushLogStrLn logger $ toLogStr msg

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -40,6 +40,7 @@ library
       Stackctl.Commands
       Stackctl.DirectoryOption
       Stackctl.FilterOption
+      Stackctl.Logger
       Stackctl.Options
       Stackctl.ParameterOption
       Stackctl.Prelude


### PR DESCRIPTION
This is much better ergonomics, and was only removed because of the
interleaving issue between `stdout` and the Logger. Now that we have
`pushLogger` that is no longer a concern, so we can bring it back
without any downsides.