### PR TITLE
Spec format improvements

### DIFF
--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -38,21 +38,21 @@ stackctl - manage CloudFormation Stacks through specifications
 
 **capture**\
 
-> Generate specifications from deployed Stacks.
+> Generate specifications for already-deployed Stacks.
 
 **changes**\
 
-> Show changes between specifications and deployed state.
+> Show changes between on-disk specifications and their deployed state.
 
 **deploy**\
 
-> Make deployed state match specifications.
+> Make deployed state match on-disk specifications.
 
 **version**\
 
 > Print the CLI's version.
 
-See individual man-pages for more details.
+Run **man stackctl \<command\>** for more details.
 
 # Stack Specifications
 

--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -162,7 +162,7 @@ And these constituent parts are used as follows:
 >   Foo: Bar
 >   Baz: Bat
 >
-> # CloudFormation (used when Stacks are generated or captured)
+> # CloudFormation
 > Parameters:
 >   - ParameterKey: Foo
 >     ParameterValue: Bar
@@ -199,7 +199,7 @@ And these constituent parts are used as follows:
 >   Foo: Bar
 >   Baz: Bat
 >
-> # CloudFormation / CloudGenesis (used when Stacks are generated or captured)
+> # CloudFormation / CloudGenesis
 > Parameters:
 >   - Key: Foo
 >     Value: Bar

--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -180,6 +180,12 @@ And these constituent parts are used as follows:
 *{.Capabilities}*\
 
 > Optional. Capabilities to use when deploying the Stack.
+>
+> Valid *Capabilities* are,
+>
+> **CAPABILITY_AUTO_EXPAND**,\
+> **CAPABILITY_IAM**, and\
+> **CAPABILITY_NAMED_IAM**
 
 *{.Tags}*\
 

--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -104,16 +104,12 @@ Actions:
     run:
       <action>: <argument...>
 
-Parameters:
-  - ParameterKey: <string>
-    ParameterValue: <string>
+Parameters: Object<string, string|number>
 
 Capabilities:
   - <capability>
 
-Tags:
-  - Key: <string>
-    Value: <string>
+Tags: Object<string, string>
 ```
 
 And these constituent parts are used as follows:
@@ -157,6 +153,29 @@ And these constituent parts are used as follows:
 *{.Parameters}*\
 
 > Optional. Parameters to use when deploying the Stack.
+>
+> The *Parameters* key can be specified in any of 3 forms:
+>
+> ```
+> # Natural (recommended)
+> Parameters:
+>   Foo: Bar
+>   Baz: Bat
+>
+> # CloudFormation (used when Stacks are generated or captured)
+> Parameters:
+>   - ParameterKey: Foo
+>     ParameterValue: Bar
+>   - ParameterKey: Baz
+>     ParameterValue: Bat
+>
+> # CloudGenesis
+> Parameters:
+>   - Key: Foo
+>     Value: Bar
+>   - Key: Baz
+>     Value: Bat
+> ```
 
 *{.Capabilities}*\
 
@@ -165,6 +184,22 @@ And these constituent parts are used as follows:
 *{.Tags}*\
 
 > Optional. Tags to use when deploying the Stack.
+>
+> The *Tags* key can be specified in either of 2 forms:
+>
+> ```
+> # Natural (recommended)
+> Tags:
+>   Foo: Bar
+>   Baz: Bat
+>
+> # CloudFormation / CloudGenesis (used when Stacks are generated or captured)
+> Parameters:
+>   - Key: Foo
+>     Value: Bar
+>   - Key: Baz
+>     Value: Bat
+> ```
 
 ## Example
 

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -123,7 +123,10 @@ prettyPrintStackSpecYaml :: Colors -> StackName -> StackSpecYaml -> [Text]
 prettyPrintStackSpecYaml Colors {..} name StackSpecYaml {..} = concat
   [ [cyan "Name" <> ": " <> green (unStackName name)]
   , [cyan "Template" <> ": " <> green (pack ssyTemplate)]
-  , ppList "Parameters" (ppParameters . map unParameterYaml) ssyParameters
+  , ppList
+    "Parameters"
+    (ppParameters . map unParameterYaml . unParametersYaml)
+    ssyParameters
   , ppList "Capabilities" ppCapabilities ssyCapabilities
   , ppList "Tags" (ppTags . map unTagYaml) ssyTags
   ]

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -128,7 +128,7 @@ prettyPrintStackSpecYaml Colors {..} name StackSpecYaml {..} = concat
     (ppParameters . map unParameterYaml . unParametersYaml)
     ssyParameters
   , ppList "Capabilities" ppCapabilities ssyCapabilities
-  , ppList "Tags" (ppTags . map unTagYaml) ssyTags
+  , ppList "Tags" (ppTags . map unTagYaml . unTagsYaml) ssyTags
   ]
  where
   ppList :: Text -> (a -> [Text]) -> Maybe a -> [Text]

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -66,7 +66,7 @@ generate Generate {..} = do
       , ssyActions = gActions
       , ssyParameters = parametersYaml . mapMaybe parameterYaml <$> gParameters
       , ssyCapabilities = gCapabilities
-      , ssyTags = map TagYaml <$> gTags
+      , ssyTags = tagsYaml . map TagYaml <$> gTags
       }
 
     stackSpec = buildStackSpec gOutputDirectory specPath specYaml

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -64,7 +64,7 @@ generate Generate {..} = do
       , ssyTemplate = templatePath
       , ssyDepends = gDepends
       , ssyActions = gActions
-      , ssyParameters = mapMaybe parameterYaml <$> gParameters
+      , ssyParameters = parametersYaml . mapMaybe parameterYaml <$> gParameters
       , ssyCapabilities = gCapabilities
       , ssyTags = map TagYaml <$> gTags
       }

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -64,7 +64,7 @@ generate Generate {..} = do
       , ssyTemplate = templatePath
       , ssyDepends = gDepends
       , ssyActions = gActions
-      , ssyParameters = map ParameterYaml <$> gParameters
+      , ssyParameters = mapMaybe parameterYaml <$> gParameters
       , ssyCapabilities = gCapabilities
       , ssyTags = map TagYaml <$> gTags
       }

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -68,7 +68,7 @@ stackSpecCapabilities :: StackSpec -> [Capability]
 stackSpecCapabilities = fromMaybe [] . ssyCapabilities . ssSpecBody
 
 stackSpecTags :: StackSpec -> [Tag]
-stackSpecTags = maybe [] (map unTagYaml) . ssyTags . ssSpecBody
+stackSpecTags = maybe [] (map unTagYaml . unTagsYaml) . ssyTags . ssSpecBody
 
 buildStackSpec :: FilePath -> StackSpecPath -> StackSpecYaml -> StackSpec
 buildStackSpec = StackSpec

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -62,7 +62,7 @@ stackSpecTemplateFile StackSpec {..} =
 
 stackSpecParameters :: StackSpec -> [Parameter]
 stackSpecParameters =
-  maybe [] (map unParameterYaml) . ssyParameters . ssSpecBody
+  maybe [] (map unParameterYaml . unParametersYaml) . ssyParameters . ssSpecBody
 
 stackSpecCapabilities :: StackSpec -> [Capability]
 stackSpecCapabilities = fromMaybe [] . ssyCapabilities . ssSpecBody

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -54,26 +54,26 @@ instance ToJSON StackSpecYaml where
 
 data ParameterYaml = ParameterYaml
   { _pyKey :: Text
-  , _pyValue :: Maybe Text
+  , _pyValue :: Maybe ParameterValue
   }
 
 parameterYaml :: Parameter -> Maybe ParameterYaml
 parameterYaml p = do
   k <- p ^. parameter_parameterKey
-  pure $ ParameterYaml k $ p ^. parameter_parameterKey
+  pure $ ParameterYaml k $ ParameterValue <$> p ^. parameter_parameterKey
 
 unParameterYaml :: ParameterYaml -> Parameter
-unParameterYaml (ParameterYaml k v) = makeParameter k v
+unParameterYaml (ParameterYaml k v) = makeParameter k $ unParameterValue <$> v
 
 instance FromJSON ParameterYaml where
   parseJSON = withObject "Parameter" $ \o ->
-    (build <$> o .: "Name" <*> o .:? "Value")
-      <|> (build <$> o .: "ParameterKey" <*> o .:? "ParameterValue")
-    where build k v = ParameterYaml k $ unParameterValue <$> v
+    (ParameterYaml <$> o .: "Name" <*> o .:? "Value")
+      <|> (ParameterYaml <$> o .: "ParameterKey" <*> o .:? "ParameterValue")
 
 newtype ParameterValue = ParameterValue
   { unParameterValue :: Text
   }
+  deriving newtype ToJSON
 
 instance FromJSON ParameterValue where
   parseJSON = \case

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -130,9 +130,6 @@ newtype TagsYaml = TagsYaml
 instance FromJSON TagsYaml where
   parseJSON = \case
     Object o -> do
-      -- NB. There are simpler ways to do this, but making sure we construct
-      -- things such that we use (.:) to read the value from each key means that
-      -- error messages will include "Parameters.{k}". See specs for an example.
       let
         parseKey k = do
           t <- newTag (Key.toText k) <$> o .: k

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -22,7 +22,7 @@ spec = do
         , "    ParameterValue: Bar\n"
         ]
 
-      let Just [ParameterYaml param] = ssyParameters
+      let Just [param] = map unParameterYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Just "Bar"
 
@@ -34,7 +34,7 @@ spec = do
         , "    ParameterValue: 80\n"
         ]
 
-      let Just [ParameterYaml param] = ssyParameters
+      let Just [param] = map unParameterYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Port"
       param ^. parameter_parameterValue `shouldBe` Just "80"
 
@@ -46,7 +46,7 @@ spec = do
         , "    ParameterValue: 3.14\n"
         ]
 
-      let Just [ParameterYaml param] = ssyParameters
+      let Just [param] = map unParameterYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Pie"
       param ^. parameter_parameterValue `shouldBe` Just "3.14"
 
@@ -62,6 +62,26 @@ spec = do
       show ex
         `shouldBe` "AesonException \"Error in $.Parameters[0].ParameterValue: Expected String or Number, got: Bool False\""
 
+    it "handles null Value" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
+        [ "Template: foo.yaml\n"
+        , "Parameters:\n"
+        , "  - ParameterKey: Foo\n"
+        , "    ParameterValue: null\n"
+        ]
+
+      let Just [param] = map unParameterYaml <$> ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Foo"
+      param ^. parameter_parameterValue `shouldBe` Nothing
+
+    it "handles missing Value" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
+        ["Template: foo.yaml\n", "Parameters:\n", "  - ParameterKey: Foo\n"]
+
+      let Just [param] = map unParameterYaml <$> ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Foo"
+      param ^. parameter_parameterValue `shouldBe` Nothing
+
     it "also accepts CloudGenesis formatted values" $ do
       StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
         [ "Template: foo.yaml\n"
@@ -70,6 +90,7 @@ spec = do
         , "    Value: Bar\n"
         ]
 
-      let Just [ParameterYaml param] = ssyParameters
+      let Just [param] = map unParameterYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Just "Bar"
+

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -22,7 +22,8 @@ spec = do
         , "    ParameterValue: Bar\n"
         ]
 
-      let Just [param] = map unParameterYaml <$> ssyParameters
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Just "Bar"
 
@@ -34,7 +35,8 @@ spec = do
         , "    ParameterValue: 80\n"
         ]
 
-      let Just [param] = map unParameterYaml <$> ssyParameters
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Port"
       param ^. parameter_parameterValue `shouldBe` Just "80"
 
@@ -46,7 +48,8 @@ spec = do
         , "    ParameterValue: 3.14\n"
         ]
 
-      let Just [param] = map unParameterYaml <$> ssyParameters
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Pie"
       param ^. parameter_parameterValue `shouldBe` Just "3.14"
 
@@ -62,6 +65,14 @@ spec = do
       show ex
         `shouldBe` "AesonException \"Error in $.Parameters[0].ParameterValue: Expected String or Number, got: Bool False\""
 
+    it "has informative errors in Object form" $ do
+      let
+        Left ex = Yaml.decodeEither' @StackSpecYaml $ mconcat
+          ["Template: foo.yaml\n", "Parameters:\n", "  Norway: no\n"]
+
+      show ex
+        `shouldBe` "AesonException \"Error in $.Parameters.Norway: Expected String or Number, got: Bool False\""
+
     it "handles null Value" $ do
       StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
         [ "Template: foo.yaml\n"
@@ -70,7 +81,8 @@ spec = do
         , "    ParameterValue: null\n"
         ]
 
-      let Just [param] = map unParameterYaml <$> ssyParameters
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Nothing
 
@@ -78,7 +90,8 @@ spec = do
       StackSpecYaml {..} <- Yaml.decodeThrow $ mconcat
         ["Template: foo.yaml\n", "Parameters:\n", "  - ParameterKey: Foo\n"]
 
-      let Just [param] = map unParameterYaml <$> ssyParameters
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Nothing
 
@@ -90,7 +103,16 @@ spec = do
         , "    Value: Bar\n"
         ]
 
-      let Just [param] = map unParameterYaml <$> ssyParameters
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Just "Bar"
 
+    it "also accepts objects" $ do
+      StackSpecYaml {..} <- Yaml.decodeThrow
+        $ mconcat ["Template: foo.yaml\n", "Parameters:\n", "  Foo: Bar\n"]
+
+      let
+        Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
+      param ^. parameter_parameterKey `shouldBe` Just "Foo"
+      param ^. parameter_parameterValue `shouldBe` Just "Bar"


### PR DESCRIPTION
Batching up two related format ergonomics improvements, then some
documentation tweaks while I was in the area:

### [Strengthen ParameterYaml type](https://github.com/freckle/stackctl/pull/26/commits/0d59ef0c2c4d05a8fc39d1ece7499503dd53bf58)

Because `ToJSON` on `ParameterYaml` had to deal with a potentially null
key in the underlying `Parameter`, we used `object []` for the case of
either side being missing. Having a Key but not a Value is actually a
realistic use-case, and we were generating:

```yaml
Parameters:
 - {}
```

When we should've generated:

```yaml
Parameters:
  - ParameterKey: Something
    ParameterValue: null
```

Or:

```yaml
Parameters:
  - ParameterKey: Something
```

To make this easier to reason about, we upgraded `ParameterYaml` to
`data` so we could hold a non-null key and possibly-null value. We wrote
`unParameterYaml` to behave the same and a `parameterYaml` to fail _on
construction_ for the invalid case of a missing key.

This makes it more natural to handle a missing value correctly.

### [Simplify ParameterYaml parsing](https://github.com/freckle/stackctl/pull/26/commits/85744795878c6d7578307854a3d48da8172710d9)

Better to retain a clearer type in the record, and make it `Text` at the
edges.

### [Support more natural syntax for Parameters](https://github.com/freckle/stackctl/pull/26/commits/18b9cc8e723c27eed90c70bd6979e704a050913a)

Originally, we used `ParameterKey`/`Value` to keep the simplest
`FromJSON` possible. Since then, we've implemented custom parsing to
correctly handle mixed-typed values and even read CloudGenesis' format.
Seems silly to continue to make our users spell things out in such a
cumbersome syntax.

This commit allows for the more natural,

```yaml
Parameters:
  Foo: Bar
  Baz: Bat
```

Similar treatment for `Tags` is soon to follow.

### [Accept simpler object syntax for Tags](https://github.com/freckle/stackctl/pull/26/commits/912afd4a7a7e40278d0a6fc4388077d175cf0c41)

See previous commit, which did the same for Parameters, for more
details.

### [Document natural formats for Parameters/Tags](https://github.com/freckle/stackctl/pull/26/commits/678c2953b5974b110d916fb1b91dace4142c4df7)

### [Document valid Capabilities values](https://github.com/freckle/stackctl/pull/26/commits/18bbfc003a04432e3d748856b2ea1600ef555373)

### [Tweak sub-command descriptions in the man-page](https://github.com/freckle/stackctl/pull/26/commits/df5e6e89e74f23ee269f577ac313fdb0c819fa52)