### PR TITLE
Merge ergonomic --filter behavior

### DIFF
--- a/src/Stackctl/FilterOption.hs
+++ b/src/Stackctl/FilterOption.hs
@@ -11,6 +11,7 @@ import Stackctl.Prelude
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Options.Applicative
+import Stackctl.AWS.CloudFormation (StackName(..))
 import Stackctl.StackSpec
 import System.FilePath.Glob
 
@@ -67,5 +68,8 @@ filterStackSpecs fo =
   filter $ \spec -> any (`matchStackSpec` spec) $ unFilterOption fo
 
 matchStackSpec :: Pattern -> StackSpec -> Bool
-matchStackSpec p spec =
-  or [match p $ stackSpecStackFile spec, match p $ stackSpecTemplateFile spec]
+matchStackSpec p spec = or
+  [ match p $ unpack $ unStackName $ stackSpecStackName spec
+  , match p $ stackSpecStackFile spec
+  , match p $ stackSpecTemplateFile spec
+  ]

--- a/src/Stackctl/FilterOption.hs
+++ b/src/Stackctl/FilterOption.hs
@@ -3,7 +3,7 @@ module Stackctl.FilterOption
   , HasFilterOption(..)
   , filterOption
   , filterOptionFromPaths
-  , filterFilePaths
+  , filterStackSpecs
   ) where
 
 import Stackctl.Prelude
@@ -11,6 +11,7 @@ import Stackctl.Prelude
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Options.Applicative
+import Stackctl.StackSpec
 import System.FilePath.Glob
 
 newtype FilterOption = FilterOption
@@ -61,5 +62,9 @@ showFilterOption =
 defaultFilterOption :: FilterOption
 defaultFilterOption = filterOptionFromPaths $ pure "**/*"
 
-filterFilePaths :: FilterOption -> [FilePath] -> [FilePath]
-filterFilePaths fo = filter $ \path -> any (`match` path) $ unFilterOption fo
+filterStackSpecs :: FilterOption -> [StackSpec] -> [StackSpec]
+filterStackSpecs fo =
+  filter $ \spec -> any (`matchStackSpec` spec) $ unFilterOption fo
+
+matchStackSpec :: Pattern -> StackSpec -> Bool
+matchStackSpec p = match p . stackSpecStackFile

--- a/src/Stackctl/FilterOption.hs
+++ b/src/Stackctl/FilterOption.hs
@@ -67,4 +67,5 @@ filterStackSpecs fo =
   filter $ \spec -> any (`matchStackSpec` spec) $ unFilterOption fo
 
 matchStackSpec :: Pattern -> StackSpec -> Bool
-matchStackSpec p = match p . stackSpecStackFile
+matchStackSpec p spec =
+  or [match p $ stackSpecStackFile spec, match p $ stackSpecTemplateFile spec]

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -100,7 +100,7 @@ runCat CatOptions {..} = do
         pure $ ssyTemplate body
 
   putTemplate 2 "templates/"
-  for_ (sort $ concat $ concat templates) $ \template -> do
+  for_ (sort $ nubOrd $ concat $ concat templates) $ \template -> do
     val <- Yaml.decodeFileThrow @_ @Value $ dir </> "templates" </> template
 
     putTemplate 4 $ green $ fromString template

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -65,13 +65,9 @@ stackSpecStackFile StackSpec {..} =
   FilePath.normalise $ ssSpecRoot </> stackSpecPathFilePath ssSpecPath
 
 -- | Normalized, relative path to the @[{root}/]templates/@ file
-stackSpecTemplateFile :: StackSpec -> StackTemplate
+stackSpecTemplateFile :: StackSpec -> FilePath
 stackSpecTemplateFile StackSpec {..} =
-  StackTemplate
-    $ FilePath.normalise
-    $ ssSpecRoot
-    </> "templates"
-    </> ssyTemplate ssSpecBody
+  FilePath.normalise $ ssSpecRoot </> "templates" </> ssyTemplate ssSpecBody
 
 stackSpecParameters :: StackSpec -> [Parameter]
 stackSpecParameters =
@@ -130,7 +126,7 @@ writeStackSpec parent stackSpec@StackSpec {..} templateBody = do
   createDirectoryIfMissing True $ takeDirectory specPath
   liftIO $ Yaml.encodeFile specPath ssSpecBody
  where
-  templatePath = unStackTemplate $ stackSpecTemplateFile stackSpec
+  templatePath = stackSpecTemplateFile stackSpec
   specPath = parent </> stackSpecPathFilePath ssSpecPath
 
 readStackSpec :: MonadIO m => FilePath -> StackSpecPath -> m StackSpec
@@ -161,7 +157,7 @@ createChangeSet
 createChangeSet spec parameters = awsCloudFormationCreateChangeSet
   (stackSpecStackName spec)
   (stackSpecStackDescription spec)
-  (stackSpecTemplateFile spec)
+  (StackTemplate $ stackSpecTemplateFile spec)
   (nubOrdOn (^. parameter_parameterKey) $ parameters <> stackSpecParameters spec
   )
   (stackSpecCapabilities spec)

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -7,6 +7,8 @@ module Stackctl.StackSpec
   , stackSpecActions
   , stackSpecParameters
   , stackSpecCapabilities
+  , stackSpecStackFile
+  , stackSpecTemplateFile
   , stackSpecTags
   , buildStackSpec
   , TemplateBody
@@ -29,6 +31,7 @@ import Stackctl.AWS
 import Stackctl.Sort
 import Stackctl.StackSpecPath
 import Stackctl.StackSpecYaml
+import qualified System.FilePath as FilePath
 import System.FilePath (takeExtension)
 import UnliftIO.Directory (createDirectoryIfMissing)
 
@@ -56,9 +59,19 @@ stackSpecDepends = fromMaybe [] . ssyDepends . ssSpecBody
 stackSpecActions :: StackSpec -> [Action]
 stackSpecActions = fromMaybe [] . ssyActions . ssSpecBody
 
+-- | Normalized, relative path to the @[{root}/]stacks/@ file
+stackSpecStackFile :: StackSpec -> FilePath
+stackSpecStackFile StackSpec {..} =
+  FilePath.normalise $ ssSpecRoot </> stackSpecPathFilePath ssSpecPath
+
+-- | Normalized, relative path to the @[{root}/]templates/@ file
 stackSpecTemplateFile :: StackSpec -> StackTemplate
 stackSpecTemplateFile StackSpec {..} =
-  StackTemplate $ ssSpecRoot </> "templates" </> ssyTemplate ssSpecBody
+  StackTemplate
+    $ FilePath.normalise
+    $ ssSpecRoot
+    </> "templates"
+    </> ssyTemplate ssSpecBody
 
 stackSpecParameters :: StackSpec -> [Parameter]
 stackSpecParameters =

--- a/test/Stackctl/FilterOptionSpec.hs
+++ b/test/Stackctl/FilterOptionSpec.hs
@@ -4,32 +4,61 @@ module Stackctl.FilterOptionSpec
 
 import Stackctl.Prelude
 
+import Stackctl.AWS
+import Stackctl.AWS.Scope
 import Stackctl.FilterOption
+import Stackctl.StackSpec
+import Stackctl.StackSpecPath
+import Stackctl.StackSpecYaml
 import Test.Hspec
 
 spec :: Spec
 spec = do
-  describe "filterFilePaths" $ do
-    it "filters paths matching any of the given patterns" $ do
+  describe "filterStackSpecs" $ do
+    it "filters specs matching any of the given patterns" $ do
       let
         option =
-          filterOptionFromPaths $ "some-path" :| ["prefix/*", "**/suffix"]
-        paths =
-          [ "some-path"
-          , "some-path-other"
-          , "other-some-path"
-          , "prefix/foo"
-          , "prefix/foo-bar"
-          , "prefix/foo-bar/prefix"
-          , "foo/suffix"
-          , "foo/bar/suffix"
-          , "foo/suffix/bar"
+          filterOptionFromPaths $ "**/some-path" :| ["**/prefix/*", "**/suffix"]
+        specs =
+          [ toSpec "some-path" "some-path"
+          , toSpec "some-other-path" "some-path-other"
+          , toSpec "other-some-path" "other-some-path"
+          , toSpec "prefix-foo" "prefix/foo"
+          , toSpec "prefix-foo-bar" "prefix/foo-bar"
+          , toSpec "prefix-foo-bar-prefix" "prefix/foo-bar/prefix"
+          , toSpec "foo-suffix" "foo/suffix"
+          , toSpec "foo-bar-suffix" "foo/bar/suffix"
+          , toSpec "foo-suffix-bar" "foo/suffix/bar"
           ]
 
-      filterFilePaths option paths
+      map specName (filterStackSpecs option specs)
         `shouldMatchList` [ "some-path"
-                          , "prefix/foo"
-                          , "prefix/foo-bar"
-                          , "foo/suffix"
-                          , "foo/bar/suffix"
+                          , "prefix-foo"
+                          , "prefix-foo-bar"
+                          , "foo-suffix"
+                          , "foo-bar-suffix"
                           ]
+
+toSpec :: Text -> FilePath -> StackSpec
+toSpec name path = buildStackSpec "." specPath specBody
+ where
+  stackName = StackName name
+  specPath = stackSpecPath scope stackName path
+  specBody = StackSpecYaml
+    { ssyDescription = Nothing
+    , ssyDepends = Nothing
+    , ssyActions = Nothing
+    , ssyTemplate = ""
+    , ssyParameters = Nothing
+    , ssyCapabilities = Nothing
+    , ssyTags = Nothing
+    }
+
+  scope = AwsScope
+    { awsAccountId = AccountId "1234567890"
+    , awsAccountName = "test-account"
+    , awsRegion = Region' "us-east-1"
+    }
+
+specName :: StackSpec -> Text
+specName = unStackName . stackSpecStackName

--- a/test/Stackctl/FilterOptionSpec.hs
+++ b/test/Stackctl/FilterOptionSpec.hs
@@ -53,6 +53,25 @@ spec = do
       map specName (filterStackSpecs option specs)
         `shouldMatchList` ["some-other-path", "other-some-path"]
 
+    it "filters specs by name too" $ do
+      let
+        option =
+          filterOptionFromPaths $ "some-name" :| ["**/prefix/*", "templates/x"]
+        specs =
+          [ toSpec "some-name" "some-path" Nothing
+          , toSpec "some-path" "some-path-other" $ Just "x"
+          , toSpec "prefix-foo" "prefix/foo" Nothing
+          , toSpec "other-some-path" "other-some-path" $ Just "z/y/t"
+          , toSpec "prefix-foo-bar" "prefix/foo-bar" Nothing
+          ]
+
+      map specName (filterStackSpecs option specs)
+        `shouldMatchList` [ "some-name"
+                          , "some-path"
+                          , "prefix-foo"
+                          , "prefix-foo-bar"
+                          ]
+
 toSpec :: Text -> FilePath -> Maybe FilePath -> StackSpec
 toSpec name path mTemplate = buildStackSpec "." specPath specBody
  where

--- a/test/Stackctl/FilterOptionSpec.hs
+++ b/test/Stackctl/FilterOptionSpec.hs
@@ -20,15 +20,15 @@ spec = do
         option =
           filterOptionFromPaths $ "**/some-path" :| ["**/prefix/*", "**/suffix"]
         specs =
-          [ toSpec "some-path" "some-path"
-          , toSpec "some-other-path" "some-path-other"
-          , toSpec "other-some-path" "other-some-path"
-          , toSpec "prefix-foo" "prefix/foo"
-          , toSpec "prefix-foo-bar" "prefix/foo-bar"
-          , toSpec "prefix-foo-bar-prefix" "prefix/foo-bar/prefix"
-          , toSpec "foo-suffix" "foo/suffix"
-          , toSpec "foo-bar-suffix" "foo/bar/suffix"
-          , toSpec "foo-suffix-bar" "foo/suffix/bar"
+          [ toSpec "some-path" "some-path" Nothing
+          , toSpec "some-other-path" "some-path-other" Nothing
+          , toSpec "other-some-path" "other-some-path" Nothing
+          , toSpec "prefix-foo" "prefix/foo" Nothing
+          , toSpec "prefix-foo-bar" "prefix/foo-bar" Nothing
+          , toSpec "prefix-foo-bar-prefix" "prefix/foo-bar/prefix" Nothing
+          , toSpec "foo-suffix" "foo/suffix" Nothing
+          , toSpec "foo-bar-suffix" "foo/bar/suffix" Nothing
+          , toSpec "foo-suffix-bar" "foo/suffix/bar" Nothing
           ]
 
       map specName (filterStackSpecs option specs)
@@ -39,8 +39,22 @@ spec = do
                           , "foo-bar-suffix"
                           ]
 
-toSpec :: Text -> FilePath -> StackSpec
-toSpec name path = buildStackSpec "." specPath specBody
+    it "filters specs by template too" $ do
+      let
+        option = filterOptionFromPaths $ "templates/x" :| ["**/y/*"]
+        specs =
+          [ toSpec "some-path" "some-path" Nothing
+          , toSpec "some-other-path" "some-path-other" $ Just "x"
+          , toSpec "prefix-foo" "prefix/foo" Nothing
+          , toSpec "other-some-path" "other-some-path" $ Just "z/y/t"
+          , toSpec "prefix-foo-bar" "prefix/foo-bar" Nothing
+          ]
+
+      map specName (filterStackSpecs option specs)
+        `shouldMatchList` ["some-other-path", "other-some-path"]
+
+toSpec :: Text -> FilePath -> Maybe FilePath -> StackSpec
+toSpec name path mTemplate = buildStackSpec "." specPath specBody
  where
   stackName = StackName name
   specPath = stackSpecPath scope stackName path
@@ -48,7 +62,7 @@ toSpec name path = buildStackSpec "." specPath specBody
     { ssyDescription = Nothing
     , ssyDepends = Nothing
     , ssyActions = Nothing
-    , ssyTemplate = ""
+    , ssyTemplate = fromMaybe path mTemplate
     , ssyParameters = Nothing
     , ssyCapabilities = Nothing
     , ssyTags = Nothing


### PR DESCRIPTION
### [Move filtering later, operate on StackSpec](https://github.com/freckle/stackctl/pull/27/commits/acd1de3420ff65b84757e0d3abea2d72d4e458b6)

This will allow us to treat filter arguments in other ways, such as
matching Stack names or template paths too. Matching names is more
intuitive for users, and matching template paths means we can remove the
logic of finding changed stacks when template paths change on CI; we can
simply pass the template paths to `--filter` and it'll do the Right
Thing.

### [Match spec templates with --filter](https://github.com/freckle/stackctl/pull/27/commits/fa716232840503bed89d081abc8e22599dc93ba4)

On CI, we currently get the list of changed stacks or templates, then we
work out which stacks use the changed templates, in order to pass their
paths to `--filter`. With this support, we can just pass the stacks and
templates.

### [Match stack names by --filter too](https://github.com/freckle/stackctl/pull/27/commits/dfffa88d965cba9a45ad4a5a0ca76b2e8f4dab88)

This is more intuitive for end-users.

### [Match --filter patterns more loosely](https://github.com/freckle/stackctl/pull/27/commits/66f2a802435e32a02034f7a8ceabe5d23f6c4da4)

Automatically add prefixes and suffixes to support filters matching
portions of paths more intuitively.

Examples:

```
--filter some/thing

  => [ some/thing               -- as-is
     , **/some/thing            -- at any depth
     , **/some/thing/*          -- as a directory
     , **/some/thing.json       -- with expected extensions
     , **/some/thing.yaml
     , **/some/thing.yml
     ]

--filter some/thing.ext

  => [ some/thing.ext           -- as-is
     , **/some/thing.ext        -- at any depth
     ]
```

### [Don't duplicate templates in stackctl-cat](https://github.com/freckle/stackctl/pull/27/commits/1dfe666983a7445e79ca35fca894c894072bc992)

If you list Stacks that share a template, they were being repeated