### PR TITLE
Fix bug in parameterYaml

### DIFF
--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -97,7 +97,7 @@ parameterYaml p = do
     $ ParameterYaml (Key.fromText k)
     $ ParameterValue
     <$> p
-    ^. parameter_parameterKey
+    ^. parameter_parameterValue
 
 unParameterYaml :: ParameterYaml -> Parameter
 unParameterYaml (ParameterYaml k v) =


### PR DESCRIPTION
This function used the key twice to build the Parameter; oops. This
doesn't affect most CLI usage since we don't construct values through
this function when reading Yaml. It does affect `capture` and
library-usage of `Generate`, where we do.
