### PR TITLE
Repository-local configuration

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -79,6 +79,7 @@ library:
     - lens
     - lens-aeson
     - monad-logger
+    - mtl
     - optparse-applicative
     - resourcet
     - rio
@@ -106,6 +107,8 @@ tests:
     main: Spec.hs
     source-dirs: test
     dependencies:
+      - bytestring
       - hspec
+      - mtl
       - stackctl
       - yaml

--- a/package.yaml
+++ b/package.yaml
@@ -107,6 +107,7 @@ tests:
     main: Spec.hs
     source-dirs: test
     dependencies:
+      - QuickCheck
       - bytestring
       - hspec
       - mtl

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -11,6 +11,7 @@ import Stackctl.Prelude
 import Stackctl.AWS
 import Stackctl.AWS.Scope
 import Stackctl.Colors
+import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption
 import Stackctl.FilterOption
 import Stackctl.Spec.Capture
@@ -23,6 +24,7 @@ import Stackctl.Version
 cat
   :: ( HasLogger env
      , HasAwsScope env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      , HasColorOption env
@@ -36,7 +38,7 @@ cat = Subcommand
   }
 
 capture
-  :: (HasAwsScope env, HasAwsEnv env, HasDirectoryOption env)
+  :: (HasAwsScope env, HasAwsEnv env, HasConfig env, HasDirectoryOption env)
   => Subcommand CaptureOptions env
 capture = Subcommand
   { name = "capture"
@@ -49,6 +51,7 @@ changes
   :: ( HasLogger env
      , HasAwsScope env
      , HasAwsEnv env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      )
@@ -64,6 +67,7 @@ deploy
   :: ( HasLogger env
      , HasAwsScope env
      , HasAwsEnv env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      )

--- a/src/Stackctl/Config.hs
+++ b/src/Stackctl/Config.hs
@@ -1,0 +1,105 @@
+module Stackctl.Config
+  ( Config(..)
+  , configParameters
+  , configTags
+  , emptyConfig
+  , HasConfig(..)
+  , ConfigError(..)
+  , loadConfig
+  , loadConfigOrExit
+  , loadConfigFrom
+  , loadConfigFromBytes
+  , applyConfig
+  ) where
+
+import Stackctl.Prelude
+
+import Control.Monad.Except
+import Data.Aeson
+import Data.Version
+import qualified Data.Yaml as Yaml
+import Paths_stackctl as Paths
+import Stackctl.Config.RequiredVersion
+import Stackctl.StackSpecYaml
+import UnliftIO.Directory (doesFileExist)
+
+data Config = Config
+  { required_version :: Maybe RequiredVersion
+  , defaults :: Maybe Defaults
+  }
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+configParameters :: Config -> Maybe ParametersYaml
+configParameters = parameters <=< defaults
+
+configTags :: Config -> Maybe TagsYaml
+configTags = tags <=< defaults
+
+emptyConfig :: Config
+emptyConfig = Config Nothing Nothing
+
+data Defaults = Defaults
+  { parameters :: Maybe ParametersYaml
+  , tags :: Maybe TagsYaml
+  }
+  deriving stock Generic
+  deriving anyclass FromJSON
+
+class HasConfig env where
+  configL :: Lens' env Config
+
+instance HasConfig Config where
+  configL = id
+
+data ConfigError
+  = ConfigInvalidYaml Yaml.ParseException
+  | ConfigInvalid (NonEmpty Text)
+  | ConfigVersionNotSatisfied RequiredVersion Version
+  deriving stock Show
+
+configErrorMessage :: ConfigError -> Message
+configErrorMessage = \case
+  ConfigInvalidYaml ex ->
+    "Configuration is not valid Yaml"
+      :# ["error" .= Yaml.prettyPrintParseException ex]
+  ConfigInvalid errs -> "Invalid configuration" :# ["errors" .= errs]
+  ConfigVersionNotSatisfied rv v ->
+    "Incompatible Stackctl version" :# ["current" .= v, "required" .= show rv]
+
+loadConfig :: MonadIO m => m (Either ConfigError Config)
+loadConfig = runExceptT $ loadConfigFrom defaultConfigFile
+
+loadConfigOrExit :: (MonadIO m, MonadLogger m) => m Config
+loadConfigOrExit = either die pure =<< loadConfig
+ where
+  die e = do
+    logError $ configErrorMessage e
+    exitFailure
+
+loadConfigFrom :: (MonadIO m, MonadError ConfigError m) => FilePath -> m Config
+loadConfigFrom path = do
+  exists <- doesFileExist path
+
+  if exists
+    then loadConfigFromBytes =<< liftIO (readFileBinary path)
+    else pure emptyConfig
+
+loadConfigFromBytes :: MonadError ConfigError m => ByteString -> m Config
+loadConfigFromBytes bs = do
+  config <- either (throwError . ConfigInvalidYaml) pure $ Yaml.decodeEither' bs
+  config <$ traverse_ checkRequiredVersion (required_version config)
+ where
+  checkRequiredVersion rv =
+    unless (isRequiredVersionSatisfied rv Paths.version)
+      $ throwError
+      $ ConfigVersionNotSatisfied rv Paths.version
+
+applyConfig :: Config -> StackSpecYaml -> StackSpecYaml
+applyConfig config ss@StackSpecYaml {..} = ss
+  { ssyParameters = configParameters config <> ssyParameters
+  , ssyTags = configTags config <> ssyTags
+  }
+
+defaultConfigFile :: FilePath
+defaultConfigFile = ".stackctl" </> "config.yaml"

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -1,0 +1,75 @@
+module Stackctl.Config.RequiredVersion
+  ( RequiredVersion(..)
+  , requiredVersionFromText
+  , isRequiredVersionSatisfied
+  ) where
+
+import Stackctl.Prelude
+
+import Data.Aeson
+import Data.List (uncons)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
+import Data.Version hiding (parseVersion)
+import qualified Data.Version as Version
+import Text.ParserCombinators.ReadP (readP_to_S)
+
+data RequiredVersion = RequiredVersion
+  { requiredVersionOp :: Text
+  , requiredVersionCompare :: Version -> Version -> Bool
+  , requiredVersionCompareWith :: Version
+  }
+
+instance Show RequiredVersion where
+  show RequiredVersion {..} =
+    unpack requiredVersionOp <> " " <> showVersion requiredVersionCompareWith
+
+instance FromJSON RequiredVersion where
+  parseJSON =
+    withText "RequiredVersion" $ either fail pure . requiredVersionFromText
+
+requiredVersionFromText :: Text -> Either String RequiredVersion
+requiredVersionFromText = fromWords . T.words
+ where
+  fromWords :: [Text] -> Either String RequiredVersion
+  fromWords = \case
+    [w] -> parseRequiredVersion "=" w
+    [op, w] -> parseRequiredVersion op w
+    _ -> Left "TODO"
+
+  parseRequiredVersion :: Text -> Text -> Either String RequiredVersion
+  parseRequiredVersion op w = do
+    v <- parseVersion w
+
+    case op of
+      "=" -> Right $ RequiredVersion op (==) v
+      "<" -> Right $ RequiredVersion op (<) v
+      "<=" -> Right $ RequiredVersion op (<=) v
+      ">" -> Right $ RequiredVersion op (>) v
+      ">=" -> Right $ RequiredVersion op (>=) v
+      "=~" -> Right $ RequiredVersion op (=~) v
+      _ ->
+        Left
+          $ "Invalid comparison operator ("
+          <> unpack op
+          <> "), may only be =, <, <=, >, >=, or =~"
+
+  parseVersion :: Text -> Either String Version
+  parseVersion t =
+    fmap (fst . NE.last)
+      $ note ("Failed to parse as a version " <> s)
+      $ NE.nonEmpty
+      $ readP_to_S Version.parseVersion s
+    where s = unpack t
+
+(=~) :: Version -> Version -> Bool
+a =~ b = a >= b && a < incrementVersion b
+ where
+  incrementVersion = onVersion $ backwards $ onHead (+ 1)
+  onVersion f = makeVersion . f . versionBranch
+  backwards f = reverse . f . reverse
+  onHead f as = maybe as (uncurry (:) . first f) $ uncons as
+
+isRequiredVersionSatisfied :: RequiredVersion -> Version -> Bool
+isRequiredVersionSatisfied RequiredVersion {..} =
+  (`requiredVersionCompare` requiredVersionCompareWith)

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -35,7 +35,10 @@ requiredVersionFromText = fromWords . T.words
   fromWords = \case
     [w] -> parseRequiredVersion "=" w
     [op, w] -> parseRequiredVersion op w
-    _ -> Left "TODO"
+    ws ->
+      Left
+        $ show (unpack $ T.unwords ws)
+        <> " did not parse as optional operator and version string"
 
   parseRequiredVersion :: Text -> Text -> Either String RequiredVersion
   parseRequiredVersion op w = do

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -2,6 +2,9 @@ module Stackctl.Config.RequiredVersion
   ( RequiredVersion(..)
   , requiredVersionFromText
   , isRequiredVersionSatisfied
+
+  -- * Exported for testing
+  , (=~)
   ) where
 
 import Stackctl.Prelude

--- a/src/Stackctl/Spec/Capture.hs
+++ b/src/Stackctl/Spec/Capture.hs
@@ -9,6 +9,7 @@ import Stackctl.Prelude
 import Options.Applicative
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption (HasDirectoryOption(..))
 import Stackctl.Spec.Generate
 import Stackctl.StackSpec
@@ -66,6 +67,7 @@ runCapture
      , MonadReader env m
      , HasAwsScope env
      , HasAwsEnv env
+     , HasConfig env
      , HasDirectoryOption env
      )
   => CaptureOptions

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -20,6 +20,7 @@ import Options.Applicative
 import Stackctl.AWS
 import Stackctl.AWS.Scope
 import Stackctl.Colors
+import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption (HasDirectoryOption(..))
 import Stackctl.FilterOption (HasFilterOption)
 import Stackctl.Spec.Discover
@@ -58,6 +59,7 @@ runCat
      , MonadReader env m
      , HasLogger env
      , HasAwsScope env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      , HasColorOption env

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -12,6 +12,7 @@ import Options.Applicative
 import Stackctl.AWS hiding (action)
 import Stackctl.AWS.Scope
 import Stackctl.Colors
+import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption (HasDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption)
 import Stackctl.ParameterOption
@@ -47,6 +48,7 @@ runChanges
      , HasLogger env
      , HasAwsScope env
      , HasAwsEnv env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      )

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -11,10 +11,11 @@ import Blammo.Logging.Logger (pushLoggerLn)
 import qualified Data.Text as T
 import Data.Time (defaultTimeLocale, formatTime, utcToLocalZonedTime)
 import Options.Applicative
+import Stackctl.Action
 import Stackctl.AWS hiding (action)
 import Stackctl.AWS.Scope
-import Stackctl.Action
 import Stackctl.Colors
+import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption (HasDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption)
 import Stackctl.ParameterOption
@@ -60,6 +61,7 @@ runDeploy
      , HasLogger env
      , HasAwsScope env
      , HasAwsEnv env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      )

--- a/src/Stackctl/Spec/Discover.hs
+++ b/src/Stackctl/Spec/Discover.hs
@@ -9,6 +9,7 @@ import Data.List.Extra (dropPrefix)
 import qualified Data.List.NonEmpty as NE
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption (HasDirectoryOption(..))
 import Stackctl.FilterOption (HasFilterOption(..), filterStackSpecs)
 import Stackctl.StackSpec
@@ -22,6 +23,7 @@ discoverSpecs
      , MonadLogger m
      , MonadReader env m
      , HasAwsScope env
+     , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
      )

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -9,6 +9,7 @@ import Stackctl.Prelude
 import Stackctl.Action
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Config (HasConfig)
 import Stackctl.Spec.Discover (buildSpecPath)
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath
@@ -41,6 +42,7 @@ generate
      , MonadUnliftIO m
      , MonadLogger m
      , MonadReader env m
+     , HasConfig env
      , HasAwsScope env
      )
   => Generate
@@ -69,7 +71,7 @@ generate Generate {..} = do
       , ssyTags = tagsYaml . map TagYaml <$> gTags
       }
 
-    stackSpec = buildStackSpec gOutputDirectory specPath specYaml
+  stackSpec <- buildStackSpec gOutputDirectory specPath specYaml
 
   withThreadContext ["stackName" .= stackSpecStackName stackSpec] $ do
     logInfo "Generating specification"

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -210,7 +210,8 @@ test-suite spec
       TypeFamilies
   ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
-      base ==4.*
+      QuickCheck
+    , base ==4.*
     , bytestring
     , hspec
     , mtl

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -38,6 +38,8 @@ library
       Stackctl.ColorOption
       Stackctl.Colors
       Stackctl.Commands
+      Stackctl.Config
+      Stackctl.Config.RequiredVersion
       Stackctl.DirectoryOption
       Stackctl.FilterOption
       Stackctl.Options
@@ -115,6 +117,7 @@ library
     , lens
     , lens-aeson
     , monad-logger
+    , mtl
     , optparse-applicative
     , resourcet
     , rio
@@ -170,6 +173,8 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Stackctl.AWS.CloudFormationSpec
+      Stackctl.Config.RequiredVersionSpec
+      Stackctl.ConfigSpec
       Stackctl.FilterOptionSpec
       Stackctl.StackDescriptionSpec
       Stackctl.StackSpecSpec
@@ -206,7 +211,9 @@ test-suite spec
   ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       base ==4.*
+    , bytestring
     , hspec
+    , mtl
     , stackctl
     , yaml
   default-language: Haskell2010

--- a/test/Stackctl/Config/RequiredVersionSpec.hs
+++ b/test/Stackctl/Config/RequiredVersionSpec.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-
 module Stackctl.Config.RequiredVersionSpec
   ( spec
   ) where
@@ -9,103 +7,74 @@ import Stackctl.Prelude
 import Data.Version
 import Stackctl.Config.RequiredVersion
 import Test.Hspec
-
-data TestCase = TestCase
-  { tcOp :: Maybe Text
-  , tcRequired :: Text
-  , tcVersions :: [([Int], Bool)]
-  }
-
--- NB. These aren't exhaustive, but I am le tired
-testCases :: [TestCase]
-testCases =
-  [ TestCase
-    Nothing
-    "1.2.3.4"
-    [ ([1, 2, 3, 4], True)
-    , ([1, 2, 3, 3], False)
-    , ([1, 2, 3, 5], False)
-    , ([1, 2, 4], False)
-    ]
-  , TestCase
-    (Just "=")
-    "1.2.3.4"
-    [ ([1, 2, 3, 4], True)
-    , ([1, 2, 3, 3], False)
-    , ([1, 2, 3, 5], False)
-    , ([1, 2, 4], False)
-    ]
-  , TestCase
-    (Just ">=")
-    "1.2.3.4"
-    [ ([1, 2, 3, 4], True)
-    , ([1, 2, 3, 5], True)
-    , ([1, 2, 4], True)
-    , ([1, 2, 3, 3], False)
-    , ([1, 2, 3], False)
-    ]
-  , TestCase
-    (Just ">=")
-    "1.2"
-    [ ([1, 2], True)
-    , ([1, 2, 1], True)
-    , ([1, 1, 9], False)
-    , ([1, 1, 9, 11], False)
-    , ([1, 0], False)
-    ]
-  , TestCase
-    (Just "<=")
-    "1.2.3.4"
-    [ ([1, 2, 3, 4], True)
-    , ([1, 2, 3, 3], True)
-    , ([1, 2, 3], True)
-    , ([1, 2, 3, 5], False)
-    , ([1, 2, 3, 4, 1], False)
-    , ([1, 2, 4], False)
-    ]
-  , TestCase
-    (Just "<=")
-    "1.2"
-    [ ([1, 2], True)
-    , ([1, 2, 1], False)
-    , ([1, 1, 9], True)
-    , ([1, 1, 9, 11], True)
-    , ([1, 0], True)
-    ]
-  , TestCase
-    (Just "=~")
-    "1.2.3.4"
-    [([1, 2, 3, 3], False), ([1, 2, 3, 4], True), ([1, 2, 3, 5], False)]
-  , TestCase
-    (Just "=~")
-    "1.2.3"
-    [ ([1, 2, 3], True)
-    , ([1, 2, 3, 1], True)
-    , ([1, 2, 3, 9], True)
-    , ([1, 2, 4], False)
-    , ([1, 2], False)
-    ]
-  ]
+import Test.QuickCheck
 
 spec :: Spec
 spec = do
-  describe "RequiredVersion" $ do
-    for_ testCases $ \TestCase {..} -> do
-      for_ tcVersions $ \(vb, satisfies) -> do
-        let
-          t = maybe "" (<> " ") tcOp <> tcRequired
-          v = makeVersion vb
+  describe "requiredVersionFromText" $ do
+    it "parses with or without operator" $ do
+      requiredVersionFromText "1.2.3-rc1" `shouldSatisfy` isRight
+      requiredVersionFromText "= 1.2.3-rc1" `shouldSatisfy` isRight
 
-          docstring =
-            "treats \""
-              <> unpack t
-              <> "\" as "
-              <> (if satisfies then "satisfied" else "NOT satisfied")
-              <> " by "
-              <> showVersion v
+    it "rejects unknown operators" $ do
+      requiredVersionFromText "!! 1.2.3" `shouldSatisfy` isLeft
 
-          Right rv = requiredVersionFromText t
+    it "rejects invalid versions" $ do
+      requiredVersionFromText "= wowOMG-2/2" `shouldSatisfy` isLeft
 
-        it docstring $ if satisfies
-          then rv `shouldSatisfy` (`isRequiredVersionSatisfied` v)
-          else rv `shouldSatisfy` (not . (`isRequiredVersionSatisfied` v))
+  describe "parsing operators" $ do
+    let prop cmp = property . uncurry . compareAsRequiredVersion cmp
+
+    it "compares exactly" $ prop (==) Nothing
+    it "compares with = " $ prop (==) $ Just "="
+    it "compares with < " $ prop (<) $ Just "<"
+    it "compares with <=" $ prop (<=) $ Just "<="
+    it "compares with > " $ prop (>) $ Just ">"
+    it "compares with >=" $ prop (>=) $ Just ">="
+    it "compares with =~" $ prop (=~) $ Just "=~"
+
+
+  describe "=~" $ do
+    it "treats equal versions as satisfying" $ do
+      makeVersion [1, 2, 3] =~ makeVersion [1, 2, 3] `shouldBe` True
+
+    it "treats older versions as non-satisfying" $ do
+      makeVersion [1, 2, 2] =~ makeVersion [1, 2, 3] `shouldBe` False
+
+    it "treats newer versions of the same branch as satisfying" $ do
+      makeVersion [1, 2, 3, 1] =~ makeVersion [1, 2, 3] `shouldBe` True
+
+    it "treats newer versions as non-satisfying" $ do
+      makeVersion [1, 2, 4] =~ makeVersion [1, 2, 3] `shouldBe` False
+
+    it "respects the number of components specified" $ do
+      makeVersion [1, 2] =~ makeVersion [1, 2] `shouldBe` True
+      makeVersion [1, 2, 3] =~ makeVersion [1, 2] `shouldBe` True
+      makeVersion [1, 1] =~ makeVersion [1, 2] `shouldBe` False
+      makeVersion [1, 3] =~ makeVersion [1, 2, 3] `shouldBe` False
+
+compareAsRequiredVersion
+  :: (Version -> Version -> Bool)
+  -- ^ Reference compare
+  -> Maybe Text
+  -- ^ Operator
+  -> Version
+  -- ^ Hypothetical required version
+  -> Version
+  -- ^ Hypotehtical current version
+  -> Bool
+compareAsRequiredVersion cmp mOperator required current =
+  runRequiredVersion mOperator required current
+    == Right (current `cmp` required)
+
+runRequiredVersion
+  :: Maybe Text
+  -- ^ Operator
+  -> Version
+  -- ^ Hypothetical required version
+  -> Version
+  -- ^ Hypothetical current version
+  -> Either String Bool
+runRequiredVersion mOperator required current =
+  (`isRequiredVersionSatisfied` current) <$> requiredVersionFromText rvText
+  where rvText = maybe "" (<> " ") mOperator <> pack (showVersion required)

--- a/test/Stackctl/Config/RequiredVersionSpec.hs
+++ b/test/Stackctl/Config/RequiredVersionSpec.hs
@@ -1,0 +1,111 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Stackctl.Config.RequiredVersionSpec
+  ( spec
+  ) where
+
+import Stackctl.Prelude
+
+import Data.Version
+import Stackctl.Config.RequiredVersion
+import Test.Hspec
+
+data TestCase = TestCase
+  { tcOp :: Maybe Text
+  , tcRequired :: Text
+  , tcVersions :: [([Int], Bool)]
+  }
+
+-- NB. These aren't exhaustive, but I am le tired
+testCases :: [TestCase]
+testCases =
+  [ TestCase
+    Nothing
+    "1.2.3.4"
+    [ ([1, 2, 3, 4], True)
+    , ([1, 2, 3, 3], False)
+    , ([1, 2, 3, 5], False)
+    , ([1, 2, 4], False)
+    ]
+  , TestCase
+    (Just "=")
+    "1.2.3.4"
+    [ ([1, 2, 3, 4], True)
+    , ([1, 2, 3, 3], False)
+    , ([1, 2, 3, 5], False)
+    , ([1, 2, 4], False)
+    ]
+  , TestCase
+    (Just ">=")
+    "1.2.3.4"
+    [ ([1, 2, 3, 4], True)
+    , ([1, 2, 3, 5], True)
+    , ([1, 2, 4], True)
+    , ([1, 2, 3, 3], False)
+    , ([1, 2, 3], False)
+    ]
+  , TestCase
+    (Just ">=")
+    "1.2"
+    [ ([1, 2], True)
+    , ([1, 2, 1], True)
+    , ([1, 1, 9], False)
+    , ([1, 1, 9, 11], False)
+    , ([1, 0], False)
+    ]
+  , TestCase
+    (Just "<=")
+    "1.2.3.4"
+    [ ([1, 2, 3, 4], True)
+    , ([1, 2, 3, 3], True)
+    , ([1, 2, 3], True)
+    , ([1, 2, 3, 5], False)
+    , ([1, 2, 3, 4, 1], False)
+    , ([1, 2, 4], False)
+    ]
+  , TestCase
+    (Just "<=")
+    "1.2"
+    [ ([1, 2], True)
+    , ([1, 2, 1], False)
+    , ([1, 1, 9], True)
+    , ([1, 1, 9, 11], True)
+    , ([1, 0], True)
+    ]
+  , TestCase
+    (Just "=~")
+    "1.2.3.4"
+    [([1, 2, 3, 3], False), ([1, 2, 3, 4], True), ([1, 2, 3, 5], False)]
+  , TestCase
+    (Just "=~")
+    "1.2.3"
+    [ ([1, 2, 3], True)
+    , ([1, 2, 3, 1], True)
+    , ([1, 2, 3, 9], True)
+    , ([1, 2, 4], False)
+    , ([1, 2], False)
+    ]
+  ]
+
+spec :: Spec
+spec = do
+  describe "RequiredVersion" $ do
+    for_ testCases $ \TestCase {..} -> do
+      for_ tcVersions $ \(vb, satisfies) -> do
+        let
+          t = maybe "" (<> " ") tcOp <> tcRequired
+          v = makeVersion vb
+
+          docstring =
+            "treats \""
+              <> unpack t
+              <> "\" as "
+              <> (if satisfies then "satisfied" else "NOT satisfied")
+              <> " by "
+              <> showVersion v
+
+          Right rv = requiredVersionFromText t
+
+        it docstring $ if satisfies
+          then rv `shouldSatisfy` (`isRequiredVersionSatisfied` v)
+          else rv `shouldSatisfy` (not . (`isRequiredVersionSatisfied` v))

--- a/test/Stackctl/ConfigSpec.hs
+++ b/test/Stackctl/ConfigSpec.hs
@@ -1,0 +1,75 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Stackctl.ConfigSpec
+  ( spec
+  ) where
+
+import Stackctl.Prelude
+
+import Control.Monad.Except
+import qualified Data.ByteString.Char8 as BS8
+import Data.Version (showVersion)
+import Paths_stackctl as Paths
+import Stackctl.AWS (makeParameter, newTag)
+import Stackctl.Config
+import Stackctl.StackSpecYaml
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "loadConfigFromBytes" $ do
+    it "loads a valid config" $ do
+      let
+        result = loadConfigFromLines
+          [ "required_version: " <> BS8.pack (showVersion Paths.version)
+          , "defaults:"
+          , "  parameters:"
+          , "    Some: Parameter"
+          , "  tags:"
+          , "    Some: Tag"
+          ]
+
+      case result of
+        Left err -> do
+          expectationFailure
+            $ "Expected to load a Config, got error: "
+            <> show err
+        Right config -> do
+          configParameters config
+            `shouldBe` Just (toParametersYaml [("Some", Just "Parameter")])
+          configTags config `shouldBe` Just (toTagsYaml [("Some", "Tag")])
+
+  describe "applyConfig" $ do
+    it "defaults missing Tags" $ do
+      let
+        specYaml = StackSpecYaml
+          { ssyDescription = Nothing
+          , ssyTemplate = ""
+          , ssyDepends = Nothing
+          , ssyActions = Nothing
+          , ssyParameters = Nothing
+          , ssyCapabilities = Nothing
+          , ssyTags = Just $ toTagsYaml [("Hi", "There"), ("Keep", "Me")]
+          }
+
+        Right config =
+          loadConfigFromBytes
+            $ "defaults:"
+            <> "\n  tags:"
+            <> "\n    From: Defaults"
+            <> "\n    Keep: \"You?\""
+
+        Just tags = ssyTags (applyConfig config specYaml)
+
+      tags `shouldBe` toTagsYaml
+        [("From", "Defaults"), ("Hi", "There"), ("Keep", "Me")]
+
+loadConfigFromLines :: MonadError ConfigError m => [ByteString] -> m Config
+loadConfigFromLines = loadConfigFromBytes . mconcat . map (<> "\n")
+
+toParametersYaml :: [(Text, Maybe Text)] -> ParametersYaml
+toParametersYaml =
+  parametersYaml . mapMaybe (parameterYaml . uncurry makeParameter)
+
+toTagsYaml :: [(Text, Text)] -> TagsYaml
+toTagsYaml = tagsYaml . map (TagYaml . uncurry newTag)

--- a/test/Stackctl/FilterOptionSpec.hs
+++ b/test/Stackctl/FilterOptionSpec.hs
@@ -8,6 +8,7 @@ import Stackctl.Prelude
 
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Config (emptyConfig)
 import Stackctl.FilterOption
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath
@@ -88,7 +89,8 @@ spec = do
         `shouldMatchList` ["some-name", "prefix-foo"]
 
 toSpec :: Text -> FilePath -> Maybe FilePath -> StackSpec
-toSpec name path mTemplate = buildStackSpec "." specPath specBody
+toSpec name path mTemplate = flip runReader emptyConfig
+  $ buildStackSpec "." specPath specBody
  where
   stackName = StackName name
   specPath = stackSpecPath scope stackName path

--- a/test/Stackctl/StackSpecSpec.hs
+++ b/test/Stackctl/StackSpecSpec.hs
@@ -6,6 +6,7 @@ import Stackctl.Prelude
 
 import Stackctl.AWS
 import Stackctl.AWS.Scope
+import Stackctl.Config (emptyConfig)
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath
 import Stackctl.StackSpecYaml
@@ -27,7 +28,8 @@ spec = do
         `shouldBe` ["iam", "roles", "networking", "app"]
 
 toSpec :: Text -> [Text] -> StackSpec
-toSpec name depends = buildStackSpec "." specPath specBody
+toSpec name depends = flip runReader emptyConfig
+  $ buildStackSpec "." specPath specBody
  where
   stackName = StackName name
   specPath = stackSpecPath scope stackName "a/b.yaml"

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -116,3 +116,29 @@ spec = do
         Just [param] = map unParameterYaml . unParametersYaml <$> ssyParameters
       param ^. parameter_parameterKey `shouldBe` Just "Foo"
       param ^. parameter_parameterValue `shouldBe` Just "Bar"
+
+  describe "ParametersYaml" $ do
+    it "has overriding Semigroup semantics" $ do
+      let
+        a = parametersYaml []
+        b = parametersYaml
+          $ catMaybes [parameterYaml $ makeParameter "Key" (Just "B")]
+        c = parametersYaml
+          $ catMaybes [parameterYaml $ makeParameter "Key" (Just "C")]
+        d = parametersYaml
+          $ catMaybes [parameterYaml $ makeParameter "Key" Nothing]
+
+      a <> b `shouldBe` b -- keeps keys in B
+      b <> c `shouldBe` c -- C overrides B (Last)
+      c <> d `shouldBe` c -- C overrides D (Just)
+      d <> c `shouldBe` c -- C overrides D (Just)
+
+  describe "TagsYaml" $ do
+    it "has overriding Semigroup semantics" $ do
+      let
+        a = tagsYaml []
+        b = tagsYaml [TagYaml $ newTag "Key" "B"]
+        c = tagsYaml [TagYaml $ newTag "Key" "C"]
+
+      a <> b `shouldBe` b -- keeps keys in B
+      b <> c `shouldBe` c -- C overrides B (Last)


### PR DESCRIPTION
### [Repository-local configuration](https://github.com/freckle/stackctl/pull/29/commits/dcac7bce54dd9c20822d563fa1b104305d2a06b5)

If present, `./.stackctl/config.yaml` is read on startup and loaded into
an application `Config` value. This configuration provides two
abilities:

- To specify a version requirement, in case your specs are relying on
  certain Stackctl features and/or bugfixes and you'd like to fully
  ensure behaviors in both local and CI contexts

- To specify some `defaults`: `Parameters` or `Tags` that should be
  applied to all Stacks deployed from this location. For example, `App`,
  `Owner`, or `DeployedBy`. It's tedious and error-prone to have to
  specify repeated things in every specification.

The config currently look like this (all values optional):

```yaml
required_version: <RequiredVersion>

defaults:
  parameters:
    <ParametersYaml>

  tags:
    <TagsYaml>
```

And here is an example:

```yaml
required_version: =~ 1.2

defaults:
  parameters:
    App: my-cool-app

  tags:
    Owner: my-cool-team
```

To support this,

- `RequiredVersion` was built and tested
- `ParametersYaml` and `TagsYaml` were given "last-wins" `Semigroup`
  instances
- `Config` and `HasConfig` were built
- `StackSpec` construction was centralized in `buildStackSpec`, which
  grew a `HasConfig` constraint, which it now uses to apply `defaults`
  for every `StackSpec` we ever construct

### [Search for the config in a few locations](https://github.com/freckle/stackctl/pull/29/commits/8acd079e1cfeed5d4db18ca4eb653b685dd2f3df)