### PR TITLE
pb/json bugfix

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -108,6 +108,7 @@ tests:
     source-dirs: test
     dependencies:
       - QuickCheck
+      - aeson
       - bytestring
       - hspec
       - mtl

--- a/src/Stackctl/AWS/Core.hs
+++ b/src/Stackctl/AWS/Core.hs
@@ -1,7 +1,5 @@
 module Stackctl.AWS.Core
-  (
-  -- * AWS via 'MonadReader'
-    AwsEnv
+  ( AwsEnv
   , HasAwsEnv(..)
   , awsEnvDiscover
   , awsSimple

--- a/src/Stackctl/AWS/Core.hs
+++ b/src/Stackctl/AWS/Core.hs
@@ -111,4 +111,4 @@ awsWithin r = local $ over (awsEnvL . unL) (within r)
 newtype AccountId = AccountId
   { unAccountId :: Text
   }
-  deriving newtype (Eq, Ord, ToJSON)
+  deriving newtype (Eq, Ord, Show, ToJSON)

--- a/src/Stackctl/AWS/Scope.hs
+++ b/src/Stackctl/AWS/Scope.hs
@@ -14,7 +14,7 @@ data AwsScope = AwsScope
   , awsAccountName :: Text
   , awsRegion :: Region
   }
-  deriving stock Generic
+  deriving stock (Eq, Show, Generic)
   deriving anyclass ToJSON
 
 class HasAwsScope env where

--- a/src/Stackctl/Action.hs
+++ b/src/Stackctl/Action.hs
@@ -31,14 +31,14 @@ data Action = Action
   { on :: ActionOn
   , run :: ActionRun
   }
-  deriving stock Generic
+  deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 newAction :: ActionOn -> ActionRun -> Action
 newAction = Action
 
 data ActionOn = PostDeploy
-  deriving stock (Eq, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance FromJSON ActionOn where
   parseJSON = withText "ActionOn" $ \case
@@ -55,6 +55,7 @@ instance ToJSON ActionOn where
 data ActionRun
   = InvokeLambdaByStackOutput Text
   | InvokeLambdaByName Text
+  deriving stock (Eq, Show)
 
 instance FromJSON ActionRun where
   parseJSON = withObject "ActionRun" $ \o -> asum

--- a/src/Stackctl/Action.hs
+++ b/src/Stackctl/Action.hs
@@ -58,10 +58,9 @@ data ActionRun
   deriving stock (Eq, Show)
 
 instance FromJSON ActionRun where
-  parseJSON = withObject "ActionRun" $ \o -> asum
-    [ InvokeLambdaByStackOutput <$> o .: "InvokeLambdaByStackOutput"
-    , InvokeLambdaByStackOutput <$> o .: "InvokeLambdaByName"
-    ]
+  parseJSON = withObject "ActionRun" $ \o ->
+    (InvokeLambdaByStackOutput <$> o .: "InvokeLambdaByStackOutput")
+      <|> (InvokeLambdaByName <$> o .: "InvokeLambdaByName")
 
 instance ToJSON ActionRun where
   toJSON = object . \case

--- a/src/Stackctl/Prelude.hs
+++ b/src/Stackctl/Prelude.hs
@@ -3,27 +3,28 @@ module Stackctl.Prelude
   , decodeUtf8
   ) where
 
-import RIO as X hiding
-  ( LogLevel(..)
-  , LogSource
-  , logDebug
-  , logDebugS
-  , logError
-  , logErrorS
-  , logInfo
-  , logInfoS
-  , logOther
-  , logOtherS
-  , logWarn
-  , logWarnS
-  )
+import RIO as X
+  hiding
+    ( LogLevel(..)
+    , LogSource
+    , logDebug
+    , logDebugS
+    , logError
+    , logErrorS
+    , logInfo
+    , logInfoS
+    , logOther
+    , logOtherS
+    , logWarn
+    , logWarnS
+    )
 
 import Blammo.Logging as X
 import Control.Error.Util as X (hush, note)
 import Data.Aeson as X (ToJSON(..), object)
 import Data.Text as X (pack, unpack)
 import System.FilePath as X
-  (dropExtension, takeBaseName, takeDirectory, (<.>), (</>))
+  ((<.>), (</>), dropExtension, takeBaseName, takeDirectory)
 import UnliftIO.Directory as X (withCurrentDirectory)
 
 {-# ANN module ("HLint: ignore Avoid restricted alias" :: String) #-}

--- a/src/Stackctl/Prelude.hs
+++ b/src/Stackctl/Prelude.hs
@@ -26,7 +26,7 @@ import System.FilePath as X
   (dropExtension, takeBaseName, takeDirectory, (<.>), (</>))
 import UnliftIO.Directory as X (withCurrentDirectory)
 
-{-# ANN module ("HLint: ignore Avoid restricted qualification" :: String) #-}
+{-# ANN module ("HLint: ignore Avoid restricted alias" :: String) #-}
 
 decodeUtf8 :: ByteString -> Text
 decodeUtf8 = decodeUtf8With lenientDecode

--- a/src/Stackctl/Prelude.hs
+++ b/src/Stackctl/Prelude.hs
@@ -3,28 +3,27 @@ module Stackctl.Prelude
   , decodeUtf8
   ) where
 
-import RIO as X
-  hiding
-    ( LogLevel(..)
-    , LogSource
-    , logDebug
-    , logDebugS
-    , logError
-    , logErrorS
-    , logInfo
-    , logInfoS
-    , logOther
-    , logOtherS
-    , logWarn
-    , logWarnS
-    )
+import RIO as X hiding
+  ( LogLevel(..)
+  , LogSource
+  , logDebug
+  , logDebugS
+  , logError
+  , logErrorS
+  , logInfo
+  , logInfoS
+  , logOther
+  , logOtherS
+  , logWarn
+  , logWarnS
+  )
 
 import Blammo.Logging as X
 import Control.Error.Util as X (hush, note)
 import Data.Aeson as X (ToJSON(..), object)
 import Data.Text as X (pack, unpack)
 import System.FilePath as X
-  ((<.>), (</>), dropExtension, takeBaseName, takeDirectory)
+  (dropExtension, takeBaseName, takeDirectory, (<.>), (</>))
 import UnliftIO.Directory as X (withCurrentDirectory)
 
 {-# ANN module ("HLint: ignore Avoid restricted alias" :: String) #-}

--- a/src/Stackctl/Prompt.hs
+++ b/src/Stackctl/Prompt.hs
@@ -41,4 +41,4 @@ promptContinue = prompt "Continue (y/n)" parse dispatch
     | x `elem` ["n", "N"] = Right False
     | otherwise = Left $ "Must be y, Y, n, or N (saw " <> x <> ")"
 
-  dispatch b = if b then pure () else exitSuccess
+  dispatch b = unless b exitSuccess

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -75,5 +75,5 @@ generate Generate {..} = do
 
   withThreadContext ["stackName" .= stackSpecStackName stackSpec] $ do
     logInfo "Generating specification"
-    writeStackSpec gOutputDirectory stackSpec gTemplateBody
+    writeStackSpec stackSpec gTemplateBody
     pure $ stackSpecPathFilePath specPath

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -68,6 +68,13 @@ stackSpecStackFile = stackSpecPathFilePath . ssSpecPath
 stackSpecTemplateFile :: StackSpec -> FilePath
 stackSpecTemplateFile = ("templates" </>) . ssyTemplate . ssSpecBody
 
+stackSpecTemplate :: StackSpec -> StackTemplate
+stackSpecTemplate spec =
+  StackTemplate
+    $ FilePath.normalise
+    $ ssSpecRoot spec
+    </> stackSpecTemplateFile spec
+
 stackSpecParameters :: StackSpec -> [Parameter]
 stackSpecParameters =
   maybe [] (map unParameterYaml . unParametersYaml) . ssyParameters . ssSpecBody
@@ -163,7 +170,7 @@ createChangeSet
 createChangeSet spec parameters = awsCloudFormationCreateChangeSet
   (stackSpecStackName spec)
   (stackSpecStackDescription spec)
-  (StackTemplate $ stackSpecTemplateFile spec)
+  (stackSpecTemplate spec)
   (nubOrdOn (^. parameter_parameterKey) $ parameters <> stackSpecParameters spec
   )
   (stackSpecCapabilities spec)

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -42,6 +42,9 @@ data StackSpec = StackSpec
   , ssSpecBody :: StackSpecYaml
   }
 
+stackSpecSpecRoot :: StackSpec -> FilePath
+stackSpecSpecRoot = ssSpecRoot
+
 stackSpecSpecPath :: StackSpec -> StackSpecPath
 stackSpecSpecPath = ssSpecPath
 
@@ -133,15 +136,16 @@ writeTemplateBody path body = do
   ext = takeExtension path
 
 writeStackSpec :: MonadUnliftIO m => StackSpec -> TemplateBody -> m ()
-writeStackSpec stackSpec@StackSpec {..} templateBody = do
+writeStackSpec stackSpec templateBody = do
   writeTemplateBody templatePath templateBody
   createDirectoryIfMissing True $ takeDirectory specPath
-  liftIO $ Yaml.encodeFile specPath ssSpecBody
+  liftIO $ Yaml.encodeFile specPath $ stackSpecSpecBody stackSpec
  where
-  templatePath =
-    FilePath.normalise $ ssSpecRoot </> stackSpecTemplateFile stackSpec
+  templatePath = unStackTemplate $ stackSpecTemplate stackSpec
   specPath =
-    FilePath.normalise $ ssSpecRoot </> stackSpecPathFilePath ssSpecPath
+    FilePath.normalise
+      $ stackSpecSpecRoot stackSpec
+      </> stackSpecStackFile stackSpec
 
 readStackSpec
   :: (MonadIO m, MonadReader env m, HasConfig env)

--- a/src/Stackctl/StackSpecPath.hs
+++ b/src/Stackctl/StackSpecPath.hs
@@ -30,6 +30,7 @@ data StackSpecPath = StackSpecPath
   , sspStackName :: StackName
   , sspPath :: FilePath
   }
+  deriving stock (Eq, Show)
 
 stackSpecPath :: AwsScope -> StackName -> FilePath -> StackSpecPath
 stackSpecPath sspAwsScope@AwsScope {..} sspStackName sspPath = StackSpecPath

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -54,7 +54,7 @@ data StackSpecYaml = StackSpecYaml
   , ssyCapabilities :: Maybe [Capability]
   , ssyTags :: Maybe TagsYaml
   }
-  deriving stock Generic
+  deriving stock (Eq, Show, Generic)
 
 instance FromJSON StackSpecYaml where
   parseJSON = genericParseJSON $ aesonPrefix id

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -42,8 +42,8 @@ import Data.Aeson.Types (typeMismatch)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Monoid (Last(..))
 import qualified Data.Text as T
-import Stackctl.AWS
 import Stackctl.Action
+import Stackctl.AWS
 
 data StackSpecYaml = StackSpecYaml
   { ssyDescription :: Maybe StackDescription

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -67,7 +67,6 @@ newtype ParametersYaml = ParametersYaml
   { unParametersYaml :: [ParameterYaml]
   }
   deriving stock (Eq, Show)
-  deriving newtype ToJSON
 
 instance Semigroup ParametersYaml where
   ParametersYaml as <> ParametersYaml bs =
@@ -95,6 +94,13 @@ instance FromJSON ParametersYaml where
         <> ", list of {ParameterKey, ParameterValue} Objects"
         <> ", or list of {Key, Value} Objects"
 
+instance ToJSON ParametersYaml where
+  toJSON = object . parametersYamlPairs
+  toEncoding = pairs . mconcat . parametersYamlPairs
+
+parametersYamlPairs :: KeyValue kv => ParametersYaml -> [kv]
+parametersYamlPairs = map parameterYamlPair . unParametersYaml
+
 parametersYaml :: [ParameterYaml] -> ParametersYaml
 parametersYaml = ParametersYaml
 
@@ -103,6 +109,14 @@ data ParameterYaml = ParameterYaml
   , pyValue :: Last ParameterValue
   }
   deriving stock (Eq, Show)
+
+instance FromJSON ParameterYaml where
+  parseJSON = withObject "Parameter" $ \o ->
+    (mkParameterYaml <$> o .: "Name" <*> o .:? "Value")
+      <|> (mkParameterYaml <$> o .: "ParameterKey" <*> o .:? "ParameterValue")
+
+parameterYamlPair :: KeyValue kv => ParameterYaml -> kv
+parameterYamlPair ParameterYaml {..} = pyKey .= pyValue
 
 mkParameterYaml :: Text -> Maybe ParameterValue -> ParameterYaml
 mkParameterYaml k = ParameterYaml (Key.fromText k) . Last
@@ -117,11 +131,6 @@ unParameterYaml :: ParameterYaml -> Parameter
 unParameterYaml (ParameterYaml k v) =
   makeParameter (Key.toText k) $ unParameterValue <$> getLast v
 
-instance FromJSON ParameterYaml where
-  parseJSON = withObject "Parameter" $ \o ->
-    (mkParameterYaml <$> o .: "Name" <*> o .:? "Value")
-      <|> (mkParameterYaml <$> o .: "ParameterKey" <*> o .:? "ParameterValue")
-
 newtype ParameterValue = ParameterValue
   { unParameterValue :: Text
   }
@@ -134,18 +143,10 @@ instance FromJSON ParameterValue where
     Number x -> pure $ ParameterValue $ dropSuffix ".0" $ pack $ show x
     x -> fail $ "Expected String or Number, got: " <> show x
 
-instance ToJSON ParameterYaml where
-  toJSON = object . parameterPairs
-  toEncoding = pairs . mconcat . parameterPairs
-
-parameterPairs :: KeyValue a => ParameterYaml -> [a]
-parameterPairs (ParameterYaml k v) = [k .= v]
-
 newtype TagsYaml = TagsYaml
   { unTagsYaml :: [TagYaml]
   }
   deriving stock (Eq, Show)
-  deriving newtype ToJSON
 
 instance Semigroup TagsYaml where
   TagsYaml as <> TagsYaml bs =
@@ -172,6 +173,13 @@ instance FromJSON TagsYaml where
     v -> typeMismatch err v
     where err = "Object or list of {Key, Value} Objects"
 
+instance ToJSON TagsYaml where
+  toJSON = object . tagsYamlPairs
+  toEncoding = pairs . mconcat . tagsYamlPairs
+
+tagsYamlPairs :: KeyValue kv => TagsYaml -> [kv]
+tagsYamlPairs = map tagYamlPair . unTagsYaml
+
 tagsYaml :: [TagYaml] -> TagsYaml
 tagsYaml = TagsYaml
 
@@ -185,12 +193,8 @@ instance FromJSON TagYaml where
     t <- newTag <$> o .: "Key" <*> o .: "Value"
     pure $ TagYaml t
 
-instance ToJSON TagYaml where
-  toJSON = object . tagPairs
-  toEncoding = pairs . mconcat . tagPairs
-
-tagPairs :: KeyValue a => TagYaml -> [a]
-tagPairs (TagYaml t) = ["Key" .= (t ^. tag_key), "Value" .= (t ^. tag_value)]
+tagYamlPair :: KeyValue kv => TagYaml -> kv
+tagYamlPair (TagYaml t) = Key.fromText (t ^. tag_key) .= (t ^. tag_value)
 
 dropSuffix :: Text -> Text -> Text
 dropSuffix suffix t = fromMaybe t $ T.stripSuffix suffix t

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -42,8 +42,8 @@ import Data.Aeson.Types (typeMismatch)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Monoid (Last(..))
 import qualified Data.Text as T
-import Stackctl.Action
 import Stackctl.AWS
+import Stackctl.Action
 
 data StackSpecYaml = StackSpecYaml
   { ssyDescription :: Maybe StackDescription

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -211,6 +211,7 @@ test-suite spec
   ghc-options: -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
       QuickCheck
+    , aeson
     , base ==4.*
     , bytestring
     , hspec

--- a/test/Stackctl/FilterOptionSpec.hs
+++ b/test/Stackctl/FilterOptionSpec.hs
@@ -88,9 +88,22 @@ spec = do
       map specName (filterStackSpecs option specs)
         `shouldMatchList` ["some-name", "prefix-foo"]
 
+  describe "filterOptionFromPaths" $ do
+    it "finds full paths (e.g. as output by generate)" $ do
+      let
+        option = filterOptionFromPaths
+          $ pure "stacks/1234567890.test-account/us-east-1/stack.yaml"
+        specs =
+          [ toSpec "some-name" "stack.yaml" Nothing
+          , toSpec "other-path" "other-stack.yaml" $ Just "x"
+          ]
+
+      map specName (filterStackSpecs option specs)
+        `shouldMatchList` ["some-name"]
+
 toSpec :: Text -> FilePath -> Maybe FilePath -> StackSpec
 toSpec name path mTemplate = flip runReader emptyConfig
-  $ buildStackSpec "." specPath specBody
+  $ buildStackSpec ".platform/specs" specPath specBody
  where
   stackName = StackName name
   specPath = stackSpecPath scope stackName path

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -9,23 +9,27 @@ import Stackctl.Prelude
 import Data.Aeson
 import qualified Data.Yaml as Yaml
 import Stackctl.AWS
-import Stackctl.StackSpecYaml
 import Stackctl.Action
+import Stackctl.StackSpecYaml
 import Test.Hspec
 
 spec :: Spec
 spec = do
   describe "From/ToJSON" $ do
     it "round trips" $ do
-      let yaml = StackSpecYaml
-            { ssyDescription = Just $ StackDescription "Testing Stack"
-            , ssyTemplate = "path/to/template.yaml"
-            , ssyDepends = Just [StackName "a-stack", StackName "another-stack"]
-            , ssyActions = Just [newAction PostDeploy $ InvokeLambdaByName "a-lambda"]
-            , ssyParameters = Just $ parametersYaml $ mapMaybe parameterYaml [makeParameter "PKey" $ Just "PValue"]
-            , ssyCapabilities = Just [Capability_CAPABILITY_IAM]
-            , ssyTags = Just $ tagsYaml [TagYaml $ newTag "TKey" "TValue"]
-            }
+      let
+        yaml = StackSpecYaml
+          { ssyDescription = Just $ StackDescription "Testing Stack"
+          , ssyTemplate = "path/to/template.yaml"
+          , ssyDepends = Just [StackName "a-stack", StackName "another-stack"]
+          , ssyActions = Just
+            [newAction PostDeploy $ InvokeLambdaByName "a-lambda"]
+          , ssyParameters = Just $ parametersYaml $ mapMaybe
+            parameterYaml
+            [makeParameter "PKey" $ Just "PValue"]
+          , ssyCapabilities = Just [Capability_CAPABILITY_IAM]
+          , ssyTags = Just $ tagsYaml [TagYaml $ newTag "TKey" "TValue"]
+          }
 
       eitherDecode (encode yaml) `shouldBe` Right yaml
 

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -8,8 +8,8 @@ import Stackctl.Prelude
 
 import Data.Aeson
 import qualified Data.Yaml as Yaml
-import Stackctl.AWS
 import Stackctl.Action
+import Stackctl.AWS
 import Stackctl.StackSpecYaml
 import Test.Hspec
 


### PR DESCRIPTION
### [Add (failing) spec on StackSpecYaml JSON](https://github.com/freckle/stackctl/pull/30/commits/d497a80c49f0ce90102c621e9d63441c13008370)

### [Fix invalid FromJSON(Action)](https://github.com/freckle/stackctl/pull/30/commits/57fc7a5a78e3df4d6b9542b5d16c36a83a2ed758)

We were loading the same constructor by either tag. I also moved from
`asum` to `(<|>)`, which produces better failures

### [Fix JSON instance for StackSpecYaml](https://github.com/freckle/stackctl/pull/30/commits/4fd844b8a4c44cd546ac141c3b8fda16162f5cea)

We didn't define a custom `ToJSON` for the `ParamtersYaml` or `TagsYaml`
objects to generate the more natural key-value style, but we _did_
define customer instances on the `ParameterYaml` and `TagYaml` element
types. This resulted in some weird JSON during generation or capture.
This commit fixes that, relying on the new failing test to be sure.

### [Update writeStackSpec to use ssSpecRoot](https://github.com/freckle/stackctl/pull/30/commits/55d19415531343922319641b8284ea2deed39d0d)

It has the same values as the separate `parent` argument, which predated
it. Doing this means that the `stackSpec...File` functions are only used
in contexts where them being relative makes more more sense.

And then being relative is also required to fix `--filter`.

### [Add spec on filtering from the output of generate](https://github.com/freckle/stackctl/pull/30/commits/3b661fbc6b25cbea70b88d15f0b519254f042cbc)

This failed until the previous commit.