### PR TITLE
Add --tag to changes/deploy, support patterns in capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.1.3.1...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.1.4.0...main)
+
+## [v1.1.4.0](https://github.com/freckle/stackctl/compare/v1.1.3.1...v1.1.4.0)
+
+- Support matching Stacks by glob in `capture`
+- Add `--tag` to `changes` and `deploy`
 
 ## [v1.1.3.1](https://github.com/freckle/stackctl/compare/v1.1.3.0...v1.1.3.1)
 

--- a/doc/stackctl-capture.1.md
+++ b/doc/stackctl-capture.1.md
@@ -43,7 +43,7 @@ If files already exist at the inferred locations, they will be overwritten.
 > Name of Stack to capture.
 >
 > Globs are also supported and all matching Stacks will be captured. When there
-> are multiple Stacks being captured, the **--path** and **--template-path**
+> are multiple Stacks being captured, the **\--path** and **\--template-path**
 > will be ignored and all Stacks will be captured to their inferred paths.
 
 # ENVIRONMENT

--- a/doc/stackctl-capture.1.md
+++ b/doc/stackctl-capture.1.md
@@ -41,6 +41,10 @@ If files already exist at the inferred locations, they will be overwritten.
 **STACK**\
 
 > Name of Stack to capture.
+>
+> Globs are also supported and all matching Stacks will be captured. When there
+> are multiple Stacks being captured, the **--path** and **--template-path**
+> will be ignored and all Stacks will be captured to their inferred paths.
 
 # ENVIRONMENT
 

--- a/doc/stackctl-changes.1.md
+++ b/doc/stackctl-changes.1.md
@@ -28,6 +28,11 @@ successful operation.
 > in overriding the Parameter as an empty string. May be specified 0 or more
 > times.
 
+**\-t**, **\--tag** *\<KEY=[VALUE]\>*\
+
+> Override the given Tag for this operation. Omitting *VALUE* will result in
+> overriding the Tag as an empty string. May be specified 0 or more times.
+
 **PATH**\
 
 > Write changes to **PATH**, instead of printing them.

--- a/doc/stackctl-deploy.1.md
+++ b/doc/stackctl-deploy.1.md
@@ -23,6 +23,11 @@ creates a Change Set and executes it after confirmation.
 > in overriding the Parameter as an empty string. May be specified 0 or more
 > times.
 
+**\-t**, **\--tag** *\<KEY=[VALUE]\>*\
+
+> Override the given Tag for this operation. Omitting *VALUE* will result in
+> overriding the Tag as an empty string. May be specified 0 or more times.
+
 **\--save-change-sets** *\<PATH\>*\
 
 > Save generated Change Sets to **PATH/STACK.json**

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.1.3.1
+version: 1.1.4.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/AWS/CloudFormation.hs
+++ b/src/Stackctl/AWS/CloudFormation.hs
@@ -222,7 +222,7 @@ awsCloudFormationGetStackNamesMatching
   => Pattern
   -> m [StackName]
 awsCloudFormationGetStackNamesMatching p = do
-  let req = newListStacks & listStacks_stackStatusFilter ?~ activeStatuses
+  let req = newListStacks & listStacks_stackStatusFilter ?~ runningStatuses
 
   runConduit
     $ awsPaginate req
@@ -483,8 +483,12 @@ stackIsRollbackComplete :: Stack -> Bool
 stackIsRollbackComplete stack =
   stack ^. stack_stackStatus == StackStatus_ROLLBACK_COMPLETE
 
-activeStatuses :: [StackStatus]
-activeStatuses = [StackStatus_CREATE_COMPLETE, StackStatus_UPDATE_COMPLETE]
+runningStatuses :: [StackStatus]
+runningStatuses =
+  [ StackStatus_CREATE_COMPLETE
+  , StackStatus_UPDATE_COMPLETE
+  , StackStatus_UPDATE_ROLLBACK_COMPLETE
+  ]
 
 _ValidationError :: AsError a => Getting (First ServiceError) a ServiceError
 _ValidationError =

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -20,10 +20,12 @@ import Stackctl.Spec.Changes.Format
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath
+import Stackctl.TagOption
 
 data ChangesOptions = ChangesOptions
   { scoFormat :: Format
   , scoParameters :: [Parameter]
+  , scoTags :: [Tag]
   , scoOutput :: Maybe FilePath
   }
 
@@ -33,6 +35,7 @@ runChangesOptions :: Parser ChangesOptions
 runChangesOptions = ChangesOptions
   <$> formatOption
   <*> many parameterOption
+  <*> many tagOption
   <*> optional (argument str
     (  metavar "PATH"
     <> help "Write changes summary to PATH"
@@ -62,7 +65,7 @@ runChanges ChangesOptions {..} = do
 
   for_ specs $ \spec -> do
     withThreadContext ["stackName" .= stackSpecStackName spec] $ do
-      emChangeSet <- createChangeSet spec scoParameters
+      emChangeSet <- createChangeSet spec scoParameters scoTags
 
       case emChangeSet of
         Left err -> do

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -23,10 +23,12 @@ import Stackctl.Prompt
 import Stackctl.Spec.Changes.Format
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
+import Stackctl.TagOption
 import UnliftIO.Directory (createDirectoryIfMissing)
 
 data DeployOptions = DeployOptions
   { sdoParameters :: [Parameter]
+  , sdoTags :: [Tag]
   , sdoSaveChangeSets :: Maybe FilePath
   , sdoDeployConfirmation :: DeployConfirmation
   , sdoClean :: Bool
@@ -37,6 +39,7 @@ data DeployOptions = DeployOptions
 runDeployOptions :: Parser DeployOptions
 runDeployOptions = DeployOptions
   <$> many parameterOption
+  <*> many tagOption
   <*> optional (strOption
     (  long "save-change-sets"
     <> metavar "DIRECTORY"
@@ -74,7 +77,7 @@ runDeploy DeployOptions {..} = do
     withThreadContext ["stackName" .= stackSpecStackName spec] $ do
       handleRollbackComplete sdoDeployConfirmation $ stackSpecStackName spec
 
-      emChangeSet <- createChangeSet spec sdoParameters
+      emChangeSet <- createChangeSet spec sdoParameters sdoTags
 
       case emChangeSet of
         Left err -> do

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -170,15 +170,16 @@ createChangeSet
      )
   => StackSpec
   -> [Parameter]
+  -> [Tag]
   -> m (Either Text (Maybe ChangeSet))
-createChangeSet spec parameters = awsCloudFormationCreateChangeSet
+createChangeSet spec parameters tags = awsCloudFormationCreateChangeSet
   (stackSpecStackName spec)
   (stackSpecStackDescription spec)
   (stackSpecTemplate spec)
   (nubOrdOn (^. parameter_parameterKey) $ parameters <> stackSpecParameters spec
   )
   (stackSpecCapabilities spec)
-  (stackSpecTags spec)
+  (nubOrdOn (^. tag_key) $ tags <> stackSpecTags spec)
 
 sortStackSpecs :: [StackSpec] -> [StackSpec]
 sortStackSpecs = sortByDependencies stackSpecStackName stackSpecDepends

--- a/src/Stackctl/TagOption.hs
+++ b/src/Stackctl/TagOption.hs
@@ -1,0 +1,25 @@
+module Stackctl.TagOption
+  ( tagOption
+  ) where
+
+import Stackctl.Prelude
+
+import qualified Data.Text as T
+import Options.Applicative
+import Stackctl.AWS.CloudFormation (Tag, newTag)
+
+tagOption :: Parser Tag
+tagOption = option (eitherReader readTag) $ mconcat
+  [ short 't'
+  , long "tag"
+  , metavar "KEY=[VALUE]"
+  , help "Override the given Tag for this operation"
+  ]
+
+readTag :: String -> Either String Tag
+readTag s = case T.breakOn "=" t of
+  (_, v) | T.null v -> Left $ "No '=' found (" <> s <> ")"
+  (k, _) | T.null k -> Left $ "Empty key (" <> s <> ")"
+  (k, "=") -> Right $ newTag k ""
+  (k, v) -> Right $ newTag k $ T.drop 1 v
+  where t = pack s

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.1.3.1
+version:        1.1.4.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -59,6 +59,7 @@ library
       Stackctl.StackSpecPath
       Stackctl.StackSpecYaml
       Stackctl.Subcommand
+      Stackctl.TagOption
       Stackctl.VerboseOption
       Stackctl.Version
       UnliftIO.Exception.Lens


### PR DESCRIPTION
We use a tag to manage expiration of our ephemeral environments. The
environments are made up of multiple Stacks with a common prefix, and
the Stacks are all tagged with `EphemeralExpiresAt={ISO timestamp}`. In
cases where we want specific environments to live a little longer, we simply
have to change this tag, but we have to do it across all the Stacks.

This operation is surprisingly tricky to script. There are many StackOverflow
answers about how to just change a Tag on a Stack, with various approaches
that come with their own trade-offs. We could write Haskell code to help, or
certainly just ask folks to use AWS Console. But (with these two commits), we
can do the following:

```sh
stackctl capture "{name}-*"
stackctl deploy --tag "EphemeralExpiresAt={timestamp}"
```

And we even get great logging, events, confirmation, error-handling, etc
for free. :ok_hand: 