### PR TITLE
Add ENV-based configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.1.4.0...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.2.0.0...main)
+
+## [v1.2.0.0](https://github.com/freckle/stackctl/compare/v1.1.3.1...v1.2.0.0)
+
+- Use more specific types in `Has{Directory,Filter,Color}Option`
+- Add environment variable configuration for `STACKCTL_{DIRECTORY,FILTERS}`
 
 ## [v1.1.4.0](https://github.com/freckle/stackctl/compare/v1.1.3.1...v1.1.4.0)
 

--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -1,6 +1,6 @@
 % STACKCTL(1) User Manual
 %
-% March 2022
+% January 2023
 
 # NAME
 
@@ -256,6 +256,22 @@ them, wait, stream events, and finally clean up.
 See **stackctl-changes(1)** and **stackctl-deploy(1)**.
 
 # ENVIRONMENT
+
+*STACKCTL_DIRECTORY*\
+
+> Environment-based alternative for *\--directory*.
+
+*STACKCTL_FILTERS*\
+
+> Environment-based alternative for *\--filters*.
+
+*LOG_\**\
+
+> Variables such as *LOG_COLOR* or *LOG_LEVEL* will be respected by the
+> underlying logging framework (Blammo). Please see its documentation for
+> complete details:
+>
+> https://github.com/freckle/blammo#configuration
 
 *AWS_PROFILE*\
 

--- a/package.yaml
+++ b/package.yaml
@@ -72,6 +72,7 @@ library:
     - cfn-flip >= 0.1.0.3 # bugfix for Condition
     - conduit
     - containers
+    - envparse
     - errors
     - exceptions
     - extra
@@ -83,6 +84,7 @@ library:
     - optparse-applicative
     - resourcet
     - rio
+    - semigroups
     - text
     - time
     - unliftio

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.1.4.0
+version: 1.2.0.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/CLI.hs
+++ b/src/Stackctl/CLI.hs
@@ -87,7 +87,7 @@ runAppT options f = do
     $ defaultLogSettings
 
   logger <- newLogger $ adjustLogSettings
-    (options ^. colorOptionL)
+    (options ^. colorOptionL . to unColorOption)
     (options ^. verboseOptionL)
     envLogSettings
 

--- a/src/Stackctl/DirectoryOption.hs
+++ b/src/Stackctl/DirectoryOption.hs
@@ -1,25 +1,41 @@
 module Stackctl.DirectoryOption
-  ( HasDirectoryOption(..)
+  ( DirectoryOption(..)
+  , defaultDirectoryOption
+  , HasDirectoryOption(..)
+  , envDirectoryOption
   , directoryOption
   ) where
 
 import Stackctl.Prelude
 
+import Data.Semigroup (Last(..))
+import qualified Env
 import Options.Applicative
 
-class HasDirectoryOption env where
-  directoryOptionL :: Lens' env FilePath
+newtype DirectoryOption = DirectoryOption
+  { unDirectoryOption :: FilePath
+  }
+  deriving newtype IsString
+  deriving Semigroup via Last DirectoryOption
 
-instance HasDirectoryOption FilePath where
+defaultDirectoryOption :: DirectoryOption
+defaultDirectoryOption = "."
+
+class HasDirectoryOption env where
+  directoryOptionL :: Lens' env DirectoryOption
+
+instance HasDirectoryOption DirectoryOption where
   directoryOptionL = id
 
-directoryOption :: Parser FilePath
+envDirectoryOption :: Env.Parser Env.Error DirectoryOption
+envDirectoryOption = Env.var (Env.str <=< Env.nonempty) "DIRECTORY"
+  $ Env.help "Operate on specifications in this directory"
+
+directoryOption :: Parser DirectoryOption
 directoryOption = option str $ mconcat
   [ short 'd'
   , long "directory"
   , metavar "PATH"
   , help "Operate on specifications in PATH"
-  , value "."
-  , showDefault
   , action "directory"
   ]

--- a/src/Stackctl/Prelude.hs
+++ b/src/Stackctl/Prelude.hs
@@ -1,6 +1,7 @@
 module Stackctl.Prelude
   ( module X
   , decodeUtf8
+  , maybeLens
   ) where
 
 import RIO as X hiding
@@ -30,3 +31,6 @@ import UnliftIO.Directory as X (withCurrentDirectory)
 
 decodeUtf8 :: ByteString -> Text
 decodeUtf8 = decodeUtf8With lenientDecode
+
+maybeLens :: a -> Lens' (Maybe a) a
+maybeLens x = lens (fromMaybe x) $ const Just

--- a/src/Stackctl/Spec/Capture.hs
+++ b/src/Stackctl/Spec/Capture.hs
@@ -10,7 +10,7 @@ import Options.Applicative
 import Stackctl.AWS
 import Stackctl.AWS.Scope
 import Stackctl.Config (HasConfig)
-import Stackctl.DirectoryOption (HasDirectoryOption(..))
+import Stackctl.DirectoryOption (HasDirectoryOption(..), unDirectoryOption)
 import Stackctl.Spec.Generate
 import Stackctl.StackSpec
 import System.FilePath.Glob
@@ -74,7 +74,7 @@ runCapture
   => CaptureOptions
   -> m ()
 runCapture CaptureOptions {..} = do
-  dir <- view directoryOptionL
+  dir <- unDirectoryOption <$> view directoryOptionL
 
   let
     setScopeName scope =

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -21,7 +21,7 @@ import Stackctl.AWS
 import Stackctl.AWS.Scope
 import Stackctl.Colors
 import Stackctl.Config (HasConfig)
-import Stackctl.DirectoryOption (HasDirectoryOption(..))
+import Stackctl.DirectoryOption (HasDirectoryOption(..), unDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption)
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
@@ -67,7 +67,7 @@ runCat
   => CatOptions
   -> m ()
 runCat CatOptions {..} = do
-  dir <- view directoryOptionL
+  dir <- unDirectoryOption <$> view directoryOptionL
   colors@Colors {..} <- getColorsStdout
   tree <- specTree <$> discoverSpecs
 

--- a/src/Stackctl/Spec/Discover.hs
+++ b/src/Stackctl/Spec/Discover.hs
@@ -10,7 +10,7 @@ import qualified Data.List.NonEmpty as NE
 import Stackctl.AWS
 import Stackctl.AWS.Scope
 import Stackctl.Config (HasConfig)
-import Stackctl.DirectoryOption (HasDirectoryOption(..))
+import Stackctl.DirectoryOption (HasDirectoryOption(..), unDirectoryOption)
 import Stackctl.FilterOption (HasFilterOption(..), filterStackSpecs)
 import Stackctl.StackSpec
 import Stackctl.StackSpecPath
@@ -29,7 +29,7 @@ discoverSpecs
      )
   => m [StackSpec]
 discoverSpecs = do
-  dir <- view directoryOptionL
+  dir <- unDirectoryOption <$> view directoryOptionL
   scope@AwsScope {..} <- view awsScopeL
   paths <- globRelativeTo
     dir

--- a/src/Stackctl/VerboseOption.hs
+++ b/src/Stackctl/VerboseOption.hs
@@ -11,6 +11,7 @@ import Blammo.Logging.LogSettings.LogLevels
 import Options.Applicative
 
 newtype Verbosity = Verbosity [()]
+  deriving newtype (Semigroup, Monoid)
 
 verbositySetLogLevels :: Verbosity -> (LogSettings -> LogSettings)
 verbositySetLogLevels (Verbosity bs) = case bs of

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.1.4.0
+version:        1.2.0.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -111,6 +111,7 @@ library
     , cfn-flip >=0.1.0.3
     , conduit
     , containers
+    , envparse
     , errors
     , exceptions
     , extra
@@ -122,6 +123,7 @@ library
     , optparse-applicative
     , resourcet
     , rio
+    , semigroups
     , text
     , time
     , unliftio


### PR DESCRIPTION
Adds support for the following ENV vars, which will behave as their
corresponding CLI flags:

- `STACKCTL_DIRECTORY` -> `--directory`
- `STACKCTL_FILTERS` -> `--filters`

This better supports use-cases where there is a single "setup" phase and
then multiple `stackctl` calls that should all use the same values for
these (e.g. GitHub Actions) without having to build the options during
setup and remember to include them on all calls.

The implementation wraps each field of `Options` in `Data.Monoid.Last`,
which is `Maybe`-like and respects the right-hand-side under `(<>)`. We
then accept a new `Env.Parser` into `runSubcommand'` and combine the
result of that such that the CLI arguments override ENV-values.

The various `Has`-classes dispatch the `Last` and `Maybe`, assigning
defaults at that point. We further enforce going through this interface
by hiding `Options` fields.

This turned out to be the least-bad approach, IMO, because we can
leverage semigroup semantics for combining options values from different
sources, while still leaving the client-code's interface (through the
`Has`-classes) untouched. A minor downside is that we can no longer use
`value` and `showDefault` and the defaults no longer appear in `--help`
for these two options. We do, however, retain it for `--color` and
`--verbose` since those don't have corresponding ENV values. User's can
set Blammo's own `LOG_*` variables (and not pass CLI arguments) if they
wish to perform ENV based setup of those behaviors.
