### PR TITLE
Fix Subcommand interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,41 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: freckle/stack-cache-action@v2
-
-      - id: stack
-        uses: freckle/stack-action@v3
-        with:
-          stack-arguments: --copy-bins
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: stackctl
-          path: |
-            ${{ steps.stack.outputs.local-bin }}/stackctl
-
-  # TODO
-  # integration-tests:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   environment: development
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-
-  #   steps:
-  #     - uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-  #         aws-region: us-east-1
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: stackctl
-  #         path: /usr/local/bin
-  #     - run: sudo chmod +x /usr/local/bin/stackctl
-  #     - run: pip install cram
-  #     - run: cram -v integration/tests
+      - uses: freckle/stack-action@v3
 
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
       - if: ${{ runner.os == 'macOS' }}
         run: brew install coreutils # need GNU install
-      - run: make dist/stackctl.tar.gz PANDOC=pandoc
+      - run: make install.check PANDOC=pandoc
       - uses: actions/upload-release-asset@v1
         id: upload-release-asset
         env:

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -29,7 +29,7 @@ cat
 cat = Subcommand
   { name = "cat"
   , description = "Pretty-print specifications"
-  , parse = runCatOptions
+  , parse = parseCatOptions
   , run = runAppSubcommand runCat
   }
 
@@ -42,7 +42,7 @@ capture
 capture = Subcommand
   { name = "capture"
   , description = "Capture deployed Stacks as specifications"
-  , parse = runCaptureOptions
+  , parse = parseCaptureOptions
   , run = runAppSubcommand runCapture
   }
 
@@ -56,7 +56,7 @@ changes
 changes = Subcommand
   { name = "changes"
   , description = "Review changes between specification and deployed state"
-  , parse = runChangesOptions
+  , parse = parseChangesOptions
   , run = runAppSubcommand runChanges
   }
 
@@ -70,7 +70,7 @@ deploy
 deploy = Subcommand
   { name = "deploy"
   , description = "Deploy specifications"
-  , parse = runDeployOptions
+  , parse = parseDeployOptions
   , run = runAppSubcommand runDeploy
   }
 

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -8,10 +8,7 @@ module Stackctl.Commands
 
 import Stackctl.Prelude
 
-import Stackctl.AWS
-import Stackctl.AWS.Scope
 import Stackctl.Colors
-import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption
 import Stackctl.FilterOption
 import Stackctl.Spec.Capture
@@ -19,70 +16,68 @@ import Stackctl.Spec.Cat
 import Stackctl.Spec.Changes
 import Stackctl.Spec.Deploy
 import Stackctl.Subcommand
+import Stackctl.VerboseOption
 import Stackctl.Version
 
 cat
-  :: ( HasLogger env
-     , HasAwsScope env
-     , HasConfig env
-     , HasDirectoryOption env
-     , HasFilterOption env
-     , HasColorOption env
+  :: ( HasColorOption options
+     , HasVerboseOption options
+     , HasDirectoryOption options
+     , HasFilterOption options
      )
-  => Subcommand CatOptions env
+  => Subcommand options CatOptions
 cat = Subcommand
   { name = "cat"
   , description = "Pretty-print specifications"
   , parse = runCatOptions
-  , run = runCat
+  , run = runAppSubcommand runCat
   }
 
 capture
-  :: (HasAwsScope env, HasAwsEnv env, HasConfig env, HasDirectoryOption env)
-  => Subcommand CaptureOptions env
+  :: ( HasColorOption options
+     , HasVerboseOption options
+     , HasDirectoryOption options
+     )
+  => Subcommand options CaptureOptions
 capture = Subcommand
   { name = "capture"
   , description = "Capture deployed Stacks as specifications"
   , parse = runCaptureOptions
-  , run = runCapture
+  , run = runAppSubcommand runCapture
   }
 
 changes
-  :: ( HasLogger env
-     , HasAwsScope env
-     , HasAwsEnv env
-     , HasConfig env
-     , HasDirectoryOption env
-     , HasFilterOption env
+  :: ( HasColorOption options
+     , HasVerboseOption options
+     , HasDirectoryOption options
+     , HasFilterOption options
      )
-  => Subcommand ChangesOptions env
+  => Subcommand options ChangesOptions
 changes = Subcommand
   { name = "changes"
   , description = "Review changes between specification and deployed state"
   , parse = runChangesOptions
-  , run = runChanges
+  , run = runAppSubcommand runChanges
   }
 
 deploy
-  :: ( HasLogger env
-     , HasAwsScope env
-     , HasAwsEnv env
-     , HasConfig env
-     , HasDirectoryOption env
-     , HasFilterOption env
+  :: ( HasColorOption options
+     , HasVerboseOption options
+     , HasDirectoryOption options
+     , HasFilterOption options
      )
-  => Subcommand DeployOptions env
+  => Subcommand options DeployOptions
 deploy = Subcommand
   { name = "deploy"
   , description = "Deploy specifications"
   , parse = runDeployOptions
-  , run = runDeploy
+  , run = runAppSubcommand runDeploy
   }
 
-version :: Subcommand () env
+version :: Subcommand options ()
 version = Subcommand
   { name = "version"
   , description = "Output the version"
   , parse = pure ()
-  , run = \() -> logVersion
+  , run = \() _ -> logVersion
   }

--- a/src/Stackctl/Spec/Capture.hs
+++ b/src/Stackctl/Spec/Capture.hs
@@ -1,6 +1,6 @@
 module Stackctl.Spec.Capture
   ( CaptureOptions(..)
-  , runCaptureOptions
+  , parseCaptureOptions
   , runCapture
   ) where
 
@@ -26,8 +26,8 @@ data CaptureOptions = CaptureOptions
 
 -- brittany-disable-next-binding
 
-runCaptureOptions :: Parser CaptureOptions
-runCaptureOptions = CaptureOptions
+parseCaptureOptions :: Parser CaptureOptions
+parseCaptureOptions = CaptureOptions
     <$> optional (strOption
       (  short 'n'
       <> long "account-name"

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -1,6 +1,6 @@
 module Stackctl.Spec.Cat
   ( CatOptions(..)
-  , runCatOptions
+  , parseCatOptions
   , runCat
   ) where
 
@@ -36,8 +36,8 @@ data CatOptions = CatOptions
 
 -- brittany-disable-next-binding
 
-runCatOptions :: Parser CatOptions
-runCatOptions = CatOptions
+parseCatOptions :: Parser CatOptions
+parseCatOptions = CatOptions
   <$> switch
     (  long "no-stacks"
     <> help "Only show templates/"

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -1,6 +1,6 @@
 module Stackctl.Spec.Changes
   ( ChangesOptions(..)
-  , runChangesOptions
+  , parseChangesOptions
   , runChanges
   ) where
 
@@ -31,8 +31,8 @@ data ChangesOptions = ChangesOptions
 
 -- brittany-disable-next-binding
 
-runChangesOptions :: Parser ChangesOptions
-runChangesOptions = ChangesOptions
+parseChangesOptions :: Parser ChangesOptions
+parseChangesOptions = ChangesOptions
   <$> formatOption
   <*> many parameterOption
   <*> many tagOption

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -1,7 +1,7 @@
 module Stackctl.Spec.Deploy
   ( DeployOptions(..)
   , DeployConfirmation(..)
-  , runDeployOptions
+  , parseDeployOptions
   , runDeploy
   ) where
 
@@ -36,8 +36,8 @@ data DeployOptions = DeployOptions
 
 -- brittany-disable-next-binding
 
-runDeployOptions :: Parser DeployOptions
-runDeployOptions = DeployOptions
+parseDeployOptions :: Parser DeployOptions
+parseDeployOptions = DeployOptions
   <$> many parameterOption
   <*> many tagOption
   <*> optional (strOption

--- a/src/Stackctl/Subcommand.hs
+++ b/src/Stackctl/Subcommand.hs
@@ -3,47 +3,70 @@ module Stackctl.Subcommand
   , subcommand
   , runSubcommand
   , runSubcommand'
+  , runAppSubcommand
   ) where
 
 import Stackctl.Prelude
 
 import qualified Env
 import Options.Applicative
-import qualified Stackctl.CLI as CLI
-import Stackctl.Colors
+import Stackctl.CLI
+import Stackctl.ColorOption
 import Stackctl.Options
 import Stackctl.VerboseOption
 
-data Subcommand options env = Subcommand
+data Subcommand options subOptions = Subcommand
   { name :: Text
   , description :: Text
-  , parse :: Parser options
-  , run :: options -> CLI.AppT env IO ()
+  , parse :: Parser subOptions
+  , run :: subOptions -> options -> IO ()
   }
 
-subcommand :: Subcommand options env -> Mod CommandFields (CLI.AppT env IO ())
+subcommand
+  :: Subcommand options subOptions -> Mod CommandFields (options -> IO ())
 subcommand Subcommand {..} =
   command (unpack name) (run <$> withInfo description parse)
 
-runSubcommand :: Mod CommandFields (CLI.AppT (CLI.App Options) IO ()) -> IO ()
+runSubcommand :: Mod CommandFields (Options -> IO a) -> IO a
 runSubcommand =
   runSubcommand' "Work with Stack specifications" envParser optionsParser
 
 -- brittany-disable-next-binding
 
 runSubcommand'
-  :: (Semigroup options, HasVerboseOption options, HasColorOption options)
+  :: Semigroup options
   => Text
   -> Env.Parser Env.Error options
   -> Parser options
-  -> Mod CommandFields (CLI.AppT (CLI.App options) IO ())
-  -> IO ()
+  -> Mod CommandFields (options -> IO a)
+  -> IO a
 runSubcommand' title parseEnv parseCLI sp = do
   (options, act) <- applyEnv
     <$> Env.parse (Env.header $ unpack title) parseEnv
     <*> execParser (withInfo title $ (,) <$> parseCLI <*> subparser sp)
-  CLI.runAppT options act
+
+  act options
   where applyEnv env = first (env <>)
+
+-- | Use this in the 'run' member of a 'Subcommand' that wants 'AppT'
+--
+-- @
+--   -- ...
+--   , parse = parseFooOptions
+--   , run = 'runAppSubcommand' runFoo
+--   }
+--
+-- runFoo :: (MonadReader env m, HasAws env) => FooOptions -> m ()
+-- runFoo = undefined
+-- @
+--
+runAppSubcommand
+  :: (HasColorOption options, HasVerboseOption options)
+  => (subOptions -> AppT (App options) IO a)
+  -> subOptions
+  -> options
+  -> IO a
+runAppSubcommand f subOptions options = runAppT options $ f subOptions
 
 withInfo :: Text -> Parser a -> ParserInfo a
 withInfo d p = info (p <**> helper) $ progDesc (unpack d) <> fullDesc


### PR DESCRIPTION
One "actual commit" and one (well, now three) drive-by:

### [Push runAppT into Subcommand{run}](https://github.com/freckle/stackctl/pull/34/commits/be09c8537409d4225b5451f6bdeca7b7d0487beb)

When all `Subcommand`s are called with `runAppT`, it meant we always had
to initialize the `App` no matter the subcommand. This led to a
surprising scenario where even something trivial like `stack version`
requires a valid AWS connection. Oops.

Making `Subcommand{run}` call `runAppT` itself is no more complicated
(especially with the `runAppSubcommand` helper), in fact it makes the
constraints in the `Commands` module simpler, and it naturally allows
for some subcommands to _not_ do that (like `version`) and so not incur
the AWS requirements.

### [Fix incorrect run-vs-parse naming](https://github.com/freckle/stackctl/pull/34/commits/fb933e2446203ceedc6e60f00bcefc8a3db87e6e)