### PR TITLE
Refactor RequiredVersion, add instances

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -59,6 +59,7 @@ library:
   dependencies:
     - Blammo >= 1.1.1.1 # pushLoggerLn, getLoggerShouldColor
     - Glob
+    - QuickCheck
     - aeson
     - aeson-casing
     - aeson-pretty

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -53,14 +53,14 @@ requiredVersionFromText = fromWords . T.words
   parseRequiredVersion op w = RequiredVersion <$> parseOp op <*> parseVersion w
 
   parseOp :: Text -> Either String RequiredVersionOp
-  parseOp op = case op of
+  parseOp = \case
     "=" -> Right RequiredVersionEQ
     "<" -> Right RequiredVersionLT
     "<=" -> Right RequiredVersionLTE
     ">" -> Right RequiredVersionGT
     ">=" -> Right RequiredVersionGTE
     "=~" -> Right RequiredVersionIsh
-    _ ->
+    op ->
       Left
         $ "Invalid comparison operator ("
         <> unpack op

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -1,5 +1,6 @@
 module Stackctl.Config.RequiredVersion
   ( RequiredVersion(..)
+  , RequiredVersionOp(..)
   , requiredVersionToText
   , requiredVersionFromText
   , isRequiredVersionSatisfied
@@ -16,6 +17,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Data.Version hiding (parseVersion)
 import qualified Data.Version as Version
+import Test.QuickCheck
 import Text.ParserCombinators.ReadP (readP_to_S)
 
 data RequiredVersion = RequiredVersion
@@ -23,6 +25,9 @@ data RequiredVersion = RequiredVersion
   , requiredVersionCompareWith :: Version
   }
   deriving stock (Eq, Show)
+
+instance Arbitrary RequiredVersion where
+  arbitrary = RequiredVersion <$> arbitrary <*> arbitrary
 
 instance FromJSON RequiredVersion where
   parseJSON =
@@ -86,7 +91,10 @@ data RequiredVersionOp
   | RequiredVersionGT
   | RequiredVersionGTE
   | RequiredVersionIsh
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Show, Bounded, Enum)
+
+instance Arbitrary RequiredVersionOp where
+  arbitrary = arbitraryBoundedEnum
 
 requiredVersionOpToText :: RequiredVersionOp -> Text
 requiredVersionOpToText = \case

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -1,5 +1,6 @@
 module Stackctl.Config.RequiredVersion
   ( RequiredVersion(..)
+  , requiredVersionToText
   , requiredVersionFromText
   , isRequiredVersionSatisfied
 
@@ -18,18 +19,23 @@ import qualified Data.Version as Version
 import Text.ParserCombinators.ReadP (readP_to_S)
 
 data RequiredVersion = RequiredVersion
-  { requiredVersionOp :: Text
-  , requiredVersionCompare :: Version -> Version -> Bool
+  { requiredVersionOp :: RequiredVersionOp
   , requiredVersionCompareWith :: Version
   }
-
-instance Show RequiredVersion where
-  show RequiredVersion {..} =
-    unpack requiredVersionOp <> " " <> showVersion requiredVersionCompareWith
+  deriving stock (Eq, Show)
 
 instance FromJSON RequiredVersion where
   parseJSON =
     withText "RequiredVersion" $ either fail pure . requiredVersionFromText
+
+instance ToJSON RequiredVersion where
+  toJSON = toJSON . requiredVersionToText
+  toEncoding = toEncoding . requiredVersionToText
+
+requiredVersionToText :: RequiredVersion -> Text
+requiredVersionToText RequiredVersion {..} =
+  requiredVersionOpToText requiredVersionOp <> " " <> pack
+    (showVersion requiredVersionCompareWith)
 
 requiredVersionFromText :: Text -> Either String RequiredVersion
 requiredVersionFromText = fromWords . T.words
@@ -44,21 +50,21 @@ requiredVersionFromText = fromWords . T.words
         <> " did not parse as optional operator and version string"
 
   parseRequiredVersion :: Text -> Text -> Either String RequiredVersion
-  parseRequiredVersion op w = do
-    v <- parseVersion w
+  parseRequiredVersion op w = RequiredVersion <$> parseOp op <*> parseVersion w
 
-    case op of
-      "=" -> Right $ RequiredVersion op (==) v
-      "<" -> Right $ RequiredVersion op (<) v
-      "<=" -> Right $ RequiredVersion op (<=) v
-      ">" -> Right $ RequiredVersion op (>) v
-      ">=" -> Right $ RequiredVersion op (>=) v
-      "=~" -> Right $ RequiredVersion op (=~) v
-      _ ->
-        Left
-          $ "Invalid comparison operator ("
-          <> unpack op
-          <> "), may only be =, <, <=, >, >=, or =~"
+  parseOp :: Text -> Either String RequiredVersionOp
+  parseOp op = case op of
+    "=" -> Right RequiredVersionEQ
+    "<" -> Right RequiredVersionLT
+    "<=" -> Right RequiredVersionLTE
+    ">" -> Right RequiredVersionGT
+    ">=" -> Right RequiredVersionGTE
+    "=~" -> Right RequiredVersionIsh
+    _ ->
+      Left
+        $ "Invalid comparison operator ("
+        <> unpack op
+        <> "), may only be =, <, <=, >, >=, or =~"
 
   parseVersion :: Text -> Either String Version
   parseVersion t =
@@ -68,6 +74,38 @@ requiredVersionFromText = fromWords . T.words
       $ readP_to_S Version.parseVersion s
     where s = unpack t
 
+isRequiredVersionSatisfied :: RequiredVersion -> Version -> Bool
+isRequiredVersionSatisfied RequiredVersion {..} =
+  (`requiredVersionCompare` requiredVersionCompareWith)
+  where requiredVersionCompare = requiredVersionOpCompare requiredVersionOp
+
+data RequiredVersionOp
+  = RequiredVersionEQ
+  | RequiredVersionLT
+  | RequiredVersionLTE
+  | RequiredVersionGT
+  | RequiredVersionGTE
+  | RequiredVersionIsh
+  deriving stock (Eq, Show)
+
+requiredVersionOpToText :: RequiredVersionOp -> Text
+requiredVersionOpToText = \case
+  RequiredVersionEQ -> "=="
+  RequiredVersionLT -> "<"
+  RequiredVersionLTE -> "<="
+  RequiredVersionGT -> ">"
+  RequiredVersionGTE -> ">="
+  RequiredVersionIsh -> "=~"
+
+requiredVersionOpCompare :: RequiredVersionOp -> Version -> Version -> Bool
+requiredVersionOpCompare = \case
+  RequiredVersionEQ -> (==)
+  RequiredVersionLT -> (<)
+  RequiredVersionLTE -> (<=)
+  RequiredVersionGT -> (>)
+  RequiredVersionGTE -> (>=)
+  RequiredVersionIsh -> (=~)
+
 (=~) :: Version -> Version -> Bool
 a =~ b = a >= b && a < incrementVersion b
  where
@@ -75,7 +113,3 @@ a =~ b = a >= b && a < incrementVersion b
   onVersion f = makeVersion . f . versionBranch
   backwards f = reverse . f . reverse
   onHead f as = maybe as (uncurry (:) . first f) $ uncons as
-
-isRequiredVersionSatisfied :: RequiredVersion -> Version -> Bool
-isRequiredVersionSatisfied RequiredVersion {..} =
-  (`requiredVersionCompare` requiredVersionCompareWith)

--- a/src/Stackctl/Config/RequiredVersion.hs
+++ b/src/Stackctl/Config/RequiredVersion.hs
@@ -60,6 +60,7 @@ requiredVersionFromText = fromWords . T.words
   parseOp :: Text -> Either String RequiredVersionOp
   parseOp = \case
     "=" -> Right RequiredVersionEQ
+    "==" -> Right RequiredVersionEQ
     "<" -> Right RequiredVersionLT
     "<=" -> Right RequiredVersionLTE
     ">" -> Right RequiredVersionGT

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -97,6 +97,7 @@ library
   build-depends:
       Blammo >=1.1.1.1
     , Glob
+    , QuickCheck
     , aeson
     , aeson-casing
     , aeson-pretty

--- a/test/Stackctl/Config/RequiredVersionSpec.hs
+++ b/test/Stackctl/Config/RequiredVersionSpec.hs
@@ -32,6 +32,7 @@ spec = do
 
     it "compares exactly" $ prop (==) Nothing
     it "compares with = " $ prop (==) $ Just "="
+    it "compares with ==" $ prop (==) $ Just "=="
     it "compares with < " $ prop (<) $ Just "<"
     it "compares with <=" $ prop (<=) $ Just "<="
     it "compares with > " $ prop (>) $ Just ">"

--- a/test/Stackctl/Config/RequiredVersionSpec.hs
+++ b/test/Stackctl/Config/RequiredVersionSpec.hs
@@ -4,6 +4,7 @@ module Stackctl.Config.RequiredVersionSpec
 
 import Stackctl.Prelude
 
+import Data.Aeson (decode, encode)
 import Data.Version
 import Stackctl.Config.RequiredVersion
 import Test.Hspec
@@ -11,6 +12,10 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = do
+  describe "JSON" $ do
+    it "round-trips" $ property $ \rv -> do
+      decode (encode @RequiredVersion rv) `shouldBe` Just rv
+
   describe "requiredVersionFromText" $ do
     it "parses with or without operator" $ do
       requiredVersionFromText "1.2.3-rc1" `shouldSatisfy` isRight


### PR DESCRIPTION
https://app.asana.com/0/13211253278157/1203652238195585/f

We need `Eq` to use `RequiredVersion` in tests. And we need `ToJSON` for
structured logging.

The current `Show` instance was custom and doesn't render a valid
Haskell syntax, which is an anti-pattern. The reason for this is that
the `requiredVersionCompare` member was itself a function, so we
couldn't just derive a `stock` `Show`. By removing that member, and
instead holding a new `RequiredVersionOp` enumeration that can be
converted to it, we can now derive `stock` `Eq` and `Show`. The new
`requiredVersionOpToText` and `requiredVersionOpCompare` functions will
need to be kept in sync, but I don't see them changing very frequently
(and we have great tests here).

We retain the more human-readable format in the new `ToJSON` instance,
because we need it in `FromJSON` (to parse Yaml correctly) and it must
of course round-trip with `ToJSON`.
