### PR TITLE
Respect LOG_COLOR

### DIFF
--- a/src/Stackctl/CLI.hs
+++ b/src/Stackctl/CLI.hs
@@ -87,7 +87,7 @@ runAppT options f = do
     $ defaultLogSettings
 
   logger <- newLogger $ adjustLogSettings
-    (options ^. colorOptionL . to unColorOption)
+    (options ^. colorOptionL)
     (options ^. verboseOptionL)
     envLogSettings
 
@@ -115,5 +115,7 @@ runAppT options f = do
     $ withThreadContext context
     $ unAppT f
 
-adjustLogSettings :: LogColor -> Verbosity -> LogSettings -> LogSettings
-adjustLogSettings lc v = setLogSettingsColor lc . verbositySetLogLevels v
+adjustLogSettings
+  :: Maybe ColorOption -> Verbosity -> LogSettings -> LogSettings
+adjustLogSettings mco v =
+  maybe id (setLogSettingsColor . unColorOption) mco . verbositySetLogLevels v

--- a/src/Stackctl/ColorOption.hs
+++ b/src/Stackctl/ColorOption.hs
@@ -1,9 +1,7 @@
 module Stackctl.ColorOption
   ( ColorOption(..)
-  , defaultColorOption
   , HasColorOption(..)
   , colorOption
-  , colorHandle
   ) where
 
 import Stackctl.Prelude
@@ -17,30 +15,9 @@ newtype ColorOption = ColorOption
   }
   deriving Semigroup via Last ColorOption
 
-defaultColorOption :: ColorOption
-defaultColorOption = ColorOption LogColorAuto
-
 class HasColorOption env where
-  colorOptionL :: Lens' env ColorOption
-
-instance HasColorOption ColorOption where
-  colorOptionL = id
+  colorOptionL :: Lens' env (Maybe ColorOption)
 
 colorOption :: Parser ColorOption
 colorOption = option (eitherReader $ fmap ColorOption . readLogColor) $ mconcat
-  [ long "color"
-  , help "When to colorize output"
-  , metavar "auto|always|never"
-  , value defaultColorOption
-  , showDefaultWith showColorOption
-  ]
-
-showColorOption :: ColorOption -> String
-showColorOption co = case unColorOption co of
-  LogColorAuto -> "auto"
-  LogColorAlways -> "always"
-  LogColorNever -> "never"
-
-colorHandle :: MonadIO m => Handle -> ColorOption -> m Bool
-colorHandle h co = shouldColorHandle settings h
-  where settings = setLogSettingsColor (unColorOption co) defaultLogSettings
+  [long "color", help "When to colorize output", metavar "auto|always|never"]

--- a/src/Stackctl/Colors.hs
+++ b/src/Stackctl/Colors.hs
@@ -1,7 +1,6 @@
 -- | Facilities for colorizing output
 module Stackctl.Colors
   ( Colors(..)
-  , HasColorOption
   , getColorsStdout
   , getColorsLogger
   , noColors
@@ -11,20 +10,18 @@ import Stackctl.Prelude
 
 import Blammo.Logging.Colors
 import Blammo.Logging.Logger
-import Stackctl.ColorOption (HasColorOption(..), colorHandle)
+import Blammo.Logging.LogSettings (shouldColorHandle)
 
 -- | Return 'Colors' based on options and 'stdout'
-getColorsStdout
-  :: (MonadIO m, MonadReader env m, HasColorOption env) => m Colors
+getColorsStdout :: (MonadIO m, MonadReader env m, HasLogger env) => m Colors
 getColorsStdout = getColorsHandle stdout
 
 -- | Return 'Colors' based on options given 'Handle'
 getColorsHandle
-  :: (MonadIO m, MonadReader env m, HasColorOption env) => Handle -> m Colors
+  :: (MonadIO m, MonadReader env m, HasLogger env) => Handle -> m Colors
 getColorsHandle h = do
-  colorOption <- view colorOptionL
-  c <- colorHandle h colorOption
-  pure $ getColors c
+  ls <- view $ loggerL . to getLoggerLogSettings
+  getColors <$> shouldColorHandle ls h
 
 -- | Return 'Colors' consistent with the ambient 'Logger'
 getColorsLogger :: (MonadReader env m, HasLogger env) => m Colors

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -8,7 +8,7 @@ module Stackctl.Commands
 
 import Stackctl.Prelude
 
-import Stackctl.Colors
+import Stackctl.ColorOption
 import Stackctl.DirectoryOption
 import Stackctl.FilterOption
 import Stackctl.Spec.Capture

--- a/src/Stackctl/Options.hs
+++ b/src/Stackctl/Options.hs
@@ -29,9 +29,6 @@ directoryL = lens oDirectory $ \x y -> x { oDirectory = y }
 filterL :: Lens' Options (Maybe FilterOption)
 filterL = lens oFilter $ \x y -> x { oFilter = y }
 
-colorL :: Lens' Options (Maybe ColorOption)
-colorL = lens oColor $ \x y -> x { oColor = y }
-
 instance HasDirectoryOption Options where
   directoryOptionL = directoryL . maybeLens defaultDirectoryOption
 
@@ -39,7 +36,7 @@ instance HasFilterOption Options where
   filterOptionL = filterL . maybeLens defaultFilterOption
 
 instance HasColorOption Options where
-  colorOptionL = colorL . maybeLens defaultColorOption
+  colorOptionL = lens oColor $ \x y -> x { oColor = y }
 
 instance HasVerboseOption Options where
   verboseOptionL = lens oVerbose $ \x y -> x { oVerbose = y }
@@ -59,5 +56,5 @@ optionsParser :: Parser Options
 optionsParser = Options
   <$> optional directoryOption
   <*> optional (filterOption "specifications")
-  <*> (Just <$> colorOption)
+  <*> optional colorOption
   <*> verboseOption

--- a/src/Stackctl/Spec/Cat.hs
+++ b/src/Stackctl/Spec/Cat.hs
@@ -62,7 +62,6 @@ runCat
      , HasConfig env
      , HasDirectoryOption env
      , HasFilterOption env
-     , HasColorOption env
      )
   => CatOptions
   -> m ()


### PR DESCRIPTION
Within Stackctl, the `--color` option was always present with a
(possibly default) value, and always applied to the `LogSettings` for
Blammo. This meant that `LOG_COLOR` was not being respected.

This is a problem for our desired CI setup, where we'd like to establish
configuration through environment variables in a single step, to impact
later calls to `stackctl` (or through `platform`).

By moving the option to a `Maybe`, and only applying it when present, we
will ensure `LOG_COLOR` is respected. This simplified a lot generally
too, which is nice. It's also following the same pattern as other
ENV-or-option settings.

The only downside is that of the pattern overall, we can't use `value`
in the options parser, so `--help` won't display defaults. This is
acceptable because we document in the man-pages anyway.
