### PR TITLE
Add --no-include-full option to stackctl-changes

### DIFF
--- a/doc/stackctl-changes.1.md
+++ b/doc/stackctl-changes.1.md
@@ -22,6 +22,11 @@ successful operation.
 
 > Output changes in **FORMAT**. See dedicated section.
 
+**\--no-include-full**\
+
+> Don't include full ChangeSet JSON details. This option only applies to the
+> *pr* format.
+
 **\-p**, **\--parameter** *\<KEY=[VALUE]\>*\
 
 > Override the given Parameter for this operation. Omitting *VALUE* will result

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -24,6 +24,7 @@ import Stackctl.TagOption
 
 data ChangesOptions = ChangesOptions
   { scoFormat :: Format
+  , scoOmitFull :: OmitFull
   , scoParameters :: [Parameter]
   , scoTags :: [Tag]
   , scoOutput :: Maybe FilePath
@@ -34,6 +35,7 @@ data ChangesOptions = ChangesOptions
 parseChangesOptions :: Parser ChangesOptions
 parseChangesOptions = ChangesOptions
   <$> formatOption
+  <*> omitFullOption
   <*> many parameterOption
   <*> many tagOption
   <*> optional (argument str
@@ -78,7 +80,8 @@ runChanges ChangesOptions {..} = do
 
           let
             name = pack $ stackSpecPathFilePath $ stackSpecSpecPath spec
-            formatted = formatChangeSet colors name scoFormat mChangeSet
+            formatted =
+              formatChangeSet colors scoOmitFull name scoFormat mChangeSet
 
           case scoOutput of
             Nothing -> pushLoggerLn formatted


### PR DESCRIPTION
The purpose of this command is primarily to build a PR comment to post
to PRs that change resources. If the comment is no different than the
last one (e.g. you make a fixup in an existing PR), our add-pr-comment
action could easily skip adding a duplicate comment. Problem is, the
full JSON contains identifiers that are different every time, causing
the comment body to never be an actual duplicate.

I've never found these details particularly valuable, so let's have an
option to omit them, making it a little easier for the duplicate-comment
logic to work for us.
