### PR TITLE
Delete corresponding Stacks when specs are removed

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -89,6 +89,7 @@ library:
     - semigroups
     - text
     - time
+    - transformers
     - unliftio
     - unliftio-core
     - unordered-containers

--- a/src/Stackctl/AWS/Scope.hs
+++ b/src/Stackctl/AWS/Scope.hs
@@ -1,13 +1,18 @@
 module Stackctl.AWS.Scope
   ( AwsScope(..)
+  , awsScopeSpecPatterns
+  , awsScopeSpecStackName
   , HasAwsScope(..)
   , fetchAwsScope
   ) where
 
 import Stackctl.Prelude
 
+import qualified Data.Text as T
 import Stackctl.AWS
 import System.Environment (lookupEnv)
+import System.FilePath (joinPath, splitPath)
+import System.FilePath.Glob (Pattern, compile, match)
 
 data AwsScope = AwsScope
   { awsAccountId :: AccountId
@@ -16,6 +21,42 @@ data AwsScope = AwsScope
   }
   deriving stock (Eq, Show, Generic)
   deriving anyclass ToJSON
+
+awsScopeSpecPatterns :: AwsScope -> [Pattern]
+awsScopeSpecPatterns AwsScope {..} =
+  [ compile
+    $ "stacks"
+    </> unpack (unAccountId awsAccountId)
+    <> ".*"
+    </> unpack (fromRegion awsRegion)
+    <> "**"
+    </> "*"
+    <.> "yaml"
+  , compile
+    $ "stacks"
+    </> "*."
+    <> unpack (unAccountId awsAccountId)
+    </> unpack (fromRegion awsRegion)
+    <> "**"
+    </> "*"
+    <.> "yaml"
+  ]
+
+awsScopeSpecStackName :: AwsScope -> FilePath -> Maybe StackName
+awsScopeSpecStackName scope path = do
+  guard $ any (`match` path) $ awsScopeSpecPatterns scope
+
+  -- once we've guarded that the path matches our scope patterns, we can play it
+  -- pretty fast and loose with the "parsing" step
+  pure
+    $ path                -- stacks/account/region/x/y.yaml
+    & splitPath           -- [stacks/, account/, region/, x/, y.yaml]
+    & drop 3              -- [x, y.yaml]
+    & joinPath            -- x/y.yaml
+    & dropExtension       -- x/y
+    & pack
+    & T.replace "/" "-"   -- x-y
+    & StackName
 
 class HasAwsScope env where
   awsScopeL :: Lens' env AwsScope

--- a/src/Stackctl/FilterOption.hs
+++ b/src/Stackctl/FilterOption.hs
@@ -6,6 +6,7 @@ module Stackctl.FilterOption
   , filterOption
   , filterOptionFromPaths
   , filterOptionFromText
+  , filterOptionToPaths
   , filterStackSpecs
   ) where
 
@@ -92,6 +93,9 @@ showFilterOption =
 
 defaultFilterOption :: FilterOption
 defaultFilterOption = filterOptionFromPaths $ pure "**/*"
+
+filterOptionToPaths :: FilterOption -> [FilePath]
+filterOptionToPaths = map decompile . NE.toList . unFilterOption
 
 filterStackSpecs :: FilterOption -> [StackSpec] -> [StackSpec]
 filterStackSpecs fo =

--- a/src/Stackctl/RemovedStack.hs
+++ b/src/Stackctl/RemovedStack.hs
@@ -1,0 +1,43 @@
+module Stackctl.RemovedStack
+  ( inferRemovedStacks
+  ) where
+
+import Stackctl.Prelude
+
+import Control.Error.Util (hoistMaybe)
+import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
+import Stackctl.AWS.CloudFormation
+import Stackctl.AWS.Core
+import Stackctl.AWS.Scope
+import Stackctl.FilterOption
+import UnliftIO.Directory (doesFileExist)
+
+inferRemovedStacks
+  :: ( MonadUnliftIO m
+     , MonadResource m
+     , MonadReader env m
+     , HasAwsEnv env
+     , HasAwsScope env
+     , HasFilterOption env
+     )
+  => m [Stack]
+inferRemovedStacks = do
+  scope <- view awsScopeL
+  paths <- view $ filterOptionL . to filterOptionToPaths
+  catMaybes <$> traverse (findRemovedStack scope) paths
+
+findRemovedStack
+  :: (MonadUnliftIO m, MonadResource m, MonadReader env m, HasAwsEnv env)
+  => AwsScope
+  -> FilePath
+  -> m (Maybe Stack)
+findRemovedStack scope path = runMaybeT $ do
+  -- The filter is a full path to a specification in the current
+  -- account/region...
+  stackName <- hoistMaybe $ awsScopeSpecStackName scope path
+
+  -- that no longer exists...
+  guard . not =<< doesFileExist path
+
+  -- but the Stack it would point to does
+  MaybeT $ awsCloudFormationDescribeStackMaybe stackName

--- a/src/Stackctl/Spec/Changes/Format.hs
+++ b/src/Stackctl/Spec/Changes/Format.hs
@@ -4,6 +4,7 @@ module Stackctl.Spec.Changes.Format
   , OmitFull(..)
   , omitFullOption
   , formatChangeSet
+  , formatRemovedStack
   , formatTTY
   ) where
 
@@ -56,6 +57,12 @@ formatChangeSet
 formatChangeSet colors omitFull name = \case
   FormatTTY -> formatTTY colors name
   FormatPullRequest -> formatPullRequest omitFull name
+
+formatRemovedStack :: Colors -> Format -> Stack -> Text
+formatRemovedStack Colors {..} format stack = case format of
+  FormatTTY -> red "DELETE" <> " stack " <> cyan name
+  FormatPullRequest -> ":x: This PR will **delete** the stack `" <> name <> "`"
+  where name = stack ^. stack_stackName
 
 formatTTY :: Colors -> Text -> Maybe ChangeSet -> Text
 formatTTY colors@Colors {..} name mChangeSet = case (mChangeSet, rChanges) of

--- a/src/Stackctl/Spec/Discover.hs
+++ b/src/Stackctl/Spec/Discover.hs
@@ -30,27 +30,8 @@ discoverSpecs
   => m [StackSpec]
 discoverSpecs = do
   dir <- unDirectoryOption <$> view directoryOptionL
-  scope@AwsScope {..} <- view awsScopeL
-  paths <- globRelativeTo
-    dir
-    [ compile
-    $ "stacks"
-    </> unpack (unAccountId awsAccountId)
-    <> ".*"
-    </> unpack (fromRegion awsRegion)
-    <> "**"
-    </> "*"
-    <.> "yaml"
-    , compile
-    $ "stacks"
-    </> "*."
-    <> unpack (unAccountId awsAccountId)
-    </> unpack (fromRegion awsRegion)
-    <> "**"
-    </> "*"
-    <.> "yaml"
-    ]
-
+  scope <- view awsScopeL
+  paths <- globRelativeTo dir $ awsScopeSpecPatterns scope
   filterOption <- view filterOptionL
 
   let

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -46,6 +46,7 @@ library
       Stackctl.ParameterOption
       Stackctl.Prelude
       Stackctl.Prompt
+      Stackctl.RemovedStack
       Stackctl.Sort
       Stackctl.Spec.Capture
       Stackctl.Spec.Cat
@@ -127,6 +128,7 @@ library
     , semigroups
     , text
     , time
+    , transformers
     , unliftio
     , unliftio-core
     , unordered-containers
@@ -177,6 +179,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Stackctl.AWS.CloudFormationSpec
+      Stackctl.AWS.ScopeSpec
       Stackctl.Config.RequiredVersionSpec
       Stackctl.ConfigSpec
       Stackctl.FilterOptionSpec

--- a/test/Stackctl/AWS/ScopeSpec.hs
+++ b/test/Stackctl/AWS/ScopeSpec.hs
@@ -1,0 +1,56 @@
+module Stackctl.AWS.ScopeSpec
+  ( spec
+  ) where
+
+import Stackctl.Prelude
+
+import Stackctl.AWS.CloudFormation
+import Stackctl.AWS.Core
+import Stackctl.AWS.Scope
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "awsScopeSpecStackName" $ do
+    let
+      scope = AwsScope
+        { awsAccountId = AccountId "123"
+        , awsAccountName = "testing"
+        , awsRegion = "us-east-1"
+        }
+
+    it "parses full paths to stacks in the current scope" $ do
+      awsScopeSpecStackName scope "stacks/123.testing/us-east-1/foo.yaml"
+        `shouldBe` Just (StackName "foo")
+
+    it "parses name.account style too" $ do
+      awsScopeSpecStackName scope "stacks/testing.123/us-east-1/foo.yaml"
+        `shouldBe` Just (StackName "foo")
+
+    it "handles sub-directories" $ do
+      awsScopeSpecStackName scope "stacks/123.testing/us-east-1/foo/bar.yaml"
+        `shouldBe` Just (StackName "foo-bar")
+
+    it "handles mismatched name" $ do
+      awsScopeSpecStackName scope "stacks/123.x/us-east-1/foo.yaml"
+        `shouldBe` Just (StackName "foo")
+
+    it "handles mismatched name in name.account style" $ do
+      awsScopeSpecStackName scope "stacks/x.123/us-east-1/foo.yaml"
+        `shouldBe` Just (StackName "foo")
+
+    it "avoids wrong region" $ do
+      awsScopeSpecStackName scope "stacks/123.testing/us-east-2/foo.yaml"
+        `shouldBe` Nothing
+
+    it "avoids arong account id" $ do
+      awsScopeSpecStackName scope "stacks/124.testing/us-east-1/foo.yaml"
+        `shouldBe` Nothing
+
+    it "requires a stacks/ prefix" $ do
+      awsScopeSpecStackName scope "123.testing/us-east-1/foo.yaml"
+        `shouldBe` Nothing
+
+    it "requires a .yaml suffix" $ do
+      awsScopeSpecStackName scope "stacks/123.testing/us-east-1/foo.yml"
+        `shouldBe` Nothing


### PR DESCRIPTION
Given:

- A full path to `stacks/.../foo/bar.yaml` is included in `--filter`
- And that path does not exist
- But the corresponding, conventionally-named Stack `foo-bar` does

Then `stackctl` will handle this as a delete, meaning it'll be shown as
such in `changes` and processed in `deploy`.

This is difficult to trigger as a manual operator, which is fine. The
idea is that operators will remove files and open a PR. Since the
removed file will be in the PR changed-files, and so included in
`--filter`, the above will apply and required removals will be processed
like any other gitops change.
