### PR TITLE
Fix incorrect environment configuration point

### DIFF
--- a/doc/stackctl.1.md
+++ b/doc/stackctl.1.md
@@ -261,9 +261,9 @@ See **stackctl-changes(1)** and **stackctl-deploy(1)**.
 
 > Environment-based alternative for *\--directory*.
 
-*STACKCTL_FILTERS*\
+*STACKCTL_FILTER*\
 
-> Environment-based alternative for *\--filters*.
+> Environment-based alternative for *\--filter*.
 
 *LOG_\**\
 

--- a/src/Stackctl/FilterOption.hs
+++ b/src/Stackctl/FilterOption.hs
@@ -38,12 +38,14 @@ instance HasFilterOption FilterOption where
   filterOptionL = id
 
 envFilterOption :: String -> Env.Parser Env.Error FilterOption
-envFilterOption items =
-  Env.var (first Env.UnreadError . readFilterOption) "FILTERS"
-    $ Env.help
-    $ "Filter "
-    <> items
-    <> " by patterns"
+envFilterOption items = var "FILTERS" <|> var "FILTER"
+ where
+  var name =
+    Env.var (first Env.UnreadError . readFilterOption) name
+      $ Env.help
+      $ "Filter "
+      <> items
+      <> " by patterns"
 
 filterOption :: String -> Parser FilterOption
 filterOption items = option (eitherReader readFilterOption) $ mconcat


### PR DESCRIPTION
The option is the singular `--filter`, so the environment variable
should be too; `STACKCTL_FILTERS` was a mistake. Since it's relatively
easy to do, we'll read it either way for now.
