### PR TITLE
Add --auto-sso option to invoke aws-sso-login if necessary

### DIFF
--- a/man/stackctl.1.ronn
+++ b/man/stackctl.1.ronn
@@ -20,6 +20,10 @@ stackctl(1) - manage CloudFormation Stacks through specifications
   * `-v`, `--verbose`:
     Log more verbosely
 
+  * `--auto-sso`=<WHEN>:
+    When to automatically run `aws sso login` in response to AWS SSO
+    authorization errors. `always`, `ask`, or `never`. Default is to `ask`.
+
 ## COMMANDS
 
   * `cat`:
@@ -225,6 +229,9 @@ See stackctl-changes(1) and stackctl-deploy(1).
 
 * `STACKCTL_FILTER`:
   Environment-based alternative for `--filter`.
+
+* `STACKCTL_AUTO_SSO`:
+  Environment-based alternative for `--auto-sso`.
 
 * `LOG_*`:
   Variables such as *LOG_COLOR* or *LOG_LEVEL* will be respected by the

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ library:
     - amazonka-core
     - amazonka-ec2
     - amazonka-lambda
+    - amazonka-sso
     - amazonka-sts
     - bytestring
     - cfn-flip >= 0.1.0.3 # bugfix for Condition
@@ -90,6 +91,7 @@ library:
     - text
     - time
     - transformers
+    - typed-process
     - unliftio
     - unliftio-core
     - unordered-containers

--- a/src/Stackctl/AutoSSO.hs
+++ b/src/Stackctl/AutoSSO.hs
@@ -1,0 +1,81 @@
+module Stackctl.AutoSSO
+  ( AutoSSOOption
+  , defaultAutoSSOOption
+  , HasAutoSSOOption(..)
+  , autoSSOOption
+  , envAutoSSOOption
+  , handleAutoSSO
+  ) where
+
+import Stackctl.Prelude
+
+import Amazonka.SSO (_UnauthorizedException)
+import Amazonka.Types (Error, ErrorMessage(..), serviceMessage)
+import Data.Semigroup (Last(..))
+import qualified Env
+import Options.Applicative
+import Stackctl.Prompt
+import System.Process.Typed
+
+data AutoSSOOption
+  = AutoSSOAlways
+  | AutoSSOAsk
+  | AutoSSONever
+  deriving Semigroup via Last AutoSSOOption
+
+defaultAutoSSOOption :: AutoSSOOption
+defaultAutoSSOOption = AutoSSOAsk
+
+readAutoSSO :: String -> Either String AutoSSOOption
+readAutoSSO = \case
+  "always" -> Right AutoSSOAlways
+  "ask" -> Right AutoSSOAsk
+  "never" -> Right AutoSSONever
+  x ->
+    Left $ "Invalid choice for auto-sso: " <> x <> ", must be always|ask|never"
+
+class HasAutoSSOOption env where
+  autoSSOOptionL :: Lens' env AutoSSOOption
+
+autoSSOOption :: Parser AutoSSOOption
+autoSSOOption = option (eitherReader readAutoSSO)
+  $ mconcat [long "auto-sso", help autoSSOHelp, metavar "WHEN"]
+
+envAutoSSOOption :: Env.Parser Env.Error AutoSSOOption
+envAutoSSOOption = Env.var (first Env.UnreadError . readAutoSSO) "AUTO_SSO"
+  $ Env.help autoSSOHelp
+
+autoSSOHelp :: IsString a => a
+autoSSOHelp = "Automatically run aws-sso-login if necessary?"
+
+handleAutoSSO
+  :: ( MonadUnliftIO m
+     , MonadReader env m
+     , MonadLogger m
+     , HasLogger env
+     , HasAutoSSOOption options
+     )
+  => options
+  -> m a
+  -> m a
+handleAutoSSO options f = do
+  catchJust (preview (_UnauthorizedException @Error)) f $ \ex -> do
+    case options ^. autoSSOOptionL of
+      AutoSSOAlways -> do
+        logWarn $ ssoErrorMessage ex
+        logInfo "Running `aws sso login' automatically"
+      AutoSSOAsk -> do
+        logWarn $ ssoErrorMessage ex
+        promptOrExit "Run `aws sso login'"
+      AutoSSONever -> do
+        logError $ ssoErrorMessage ex
+        exitFailure
+
+    runProcess_ $ proc "aws" ["sso", "login"]
+    f
+ where
+  ssoErrorMessage ex =
+    "AWS SSO authorization error"
+      :# [ "message" .= fmap fromErrorMessage (ex ^. serviceMessage)
+         , "hint" .= ("Run `aws sso login' and try again" :: Text)
+         ]

--- a/src/Stackctl/Commands.hs
+++ b/src/Stackctl/Commands.hs
@@ -4,6 +4,7 @@ module Stackctl.Commands
 
 import Stackctl.Prelude
 
+import Stackctl.AutoSSO
 import Stackctl.ColorOption
 import Stackctl.DirectoryOption
 import Stackctl.FilterOption
@@ -21,6 +22,7 @@ cat
      , HasVerboseOption options
      , HasDirectoryOption options
      , HasFilterOption options
+     , HasAutoSSOOption options
      )
   => Subcommand options CatOptions
 cat = Subcommand
@@ -34,6 +36,7 @@ capture
   :: ( HasColorOption options
      , HasVerboseOption options
      , HasDirectoryOption options
+     , HasAutoSSOOption options
      )
   => Subcommand options CaptureOptions
 capture = Subcommand
@@ -48,6 +51,7 @@ changes
      , HasVerboseOption options
      , HasDirectoryOption options
      , HasFilterOption options
+     , HasAutoSSOOption options
      )
   => Subcommand options ChangesOptions
 changes = Subcommand
@@ -62,6 +66,7 @@ deploy
      , HasVerboseOption options
      , HasDirectoryOption options
      , HasFilterOption options
+     , HasAutoSSOOption options
      )
   => Subcommand options DeployOptions
 deploy = Subcommand
@@ -76,6 +81,7 @@ list
      , HasVerboseOption options
      , HasDirectoryOption options
      , HasFilterOption options
+     , HasAutoSSOOption options
      )
   => Subcommand options ListOptions
 list = Subcommand

--- a/src/Stackctl/Options.hs
+++ b/src/Stackctl/Options.hs
@@ -9,6 +9,7 @@ import Stackctl.Prelude
 import Data.Semigroup.Generic
 import qualified Env
 import Options.Applicative
+import Stackctl.AutoSSO
 import Stackctl.ColorOption
 import Stackctl.DirectoryOption
 import Stackctl.FilterOption
@@ -19,6 +20,7 @@ data Options = Options
   , oFilter :: Maybe FilterOption
   , oColor :: Maybe ColorOption
   , oVerbose :: Verbosity
+  , oAutoSSO :: Maybe AutoSSOOption
   }
   deriving stock Generic
   deriving Semigroup via GenericSemigroupMonoid Options
@@ -28,6 +30,9 @@ directoryL = lens oDirectory $ \x y -> x { oDirectory = y }
 
 filterL :: Lens' Options (Maybe FilterOption)
 filterL = lens oFilter $ \x y -> x { oFilter = y }
+
+autoSSOL :: Lens' Options (Maybe AutoSSOOption)
+autoSSOL = lens oAutoSSO $ \x y -> x { oAutoSSO = y }
 
 instance HasDirectoryOption Options where
   directoryOptionL = directoryL . maybeLens defaultDirectoryOption
@@ -41,6 +46,9 @@ instance HasColorOption Options where
 instance HasVerboseOption Options where
   verboseOptionL = lens oVerbose $ \x y -> x { oVerbose = y }
 
+instance HasAutoSSOOption Options where
+  autoSSOOptionL = autoSSOL . maybeLens defaultAutoSSOOption
+
 -- brittany-disable-next-binding
 
 envParser :: Env.Parser Env.Error Options
@@ -49,6 +57,7 @@ envParser = Env.prefixed "STACKCTL_" $ Options
   <*> optional (envFilterOption "specifications")
   <*> pure mempty -- use LOG_COLOR
   <*> pure mempty -- use LOG_LEVEL
+  <*> optional envAutoSSOOption
 
 -- brittany-disable-next-binding
 
@@ -58,3 +67,4 @@ optionsParser = Options
   <*> optional (filterOption "specifications")
   <*> optional colorOption
   <*> verboseOption
+  <*> optional autoSSOOption

--- a/src/Stackctl/Prompt.hs
+++ b/src/Stackctl/Prompt.hs
@@ -1,6 +1,7 @@
 module Stackctl.Prompt
   ( prompt
   , promptContinue
+  , promptOrExit
   ) where
 
 import Stackctl.Prelude
@@ -34,7 +35,13 @@ prompt message parse dispatch = do
 
 promptContinue
   :: (MonadIO m, MonadLogger m, MonadReader env m, HasLogger env) => m ()
-promptContinue = prompt "Continue (y/n)" parse dispatch
+promptContinue = promptOrExit "Continue"
+
+promptOrExit
+  :: (MonadIO m, MonadLogger m, MonadReader env m, HasLogger env)
+  => Text
+  -> m ()
+promptOrExit msg = prompt (msg <> " (y/n)") parse dispatch
  where
   parse x
     | x `elem` ["y", "Y"] = Right True

--- a/src/Stackctl/Subcommand.hs
+++ b/src/Stackctl/Subcommand.hs
@@ -10,6 +10,7 @@ import Stackctl.Prelude
 
 import qualified Env
 import Options.Applicative
+import Stackctl.AutoSSO
 import Stackctl.CLI
 import Stackctl.ColorOption
 import Stackctl.Options
@@ -61,7 +62,10 @@ runSubcommand' title parseEnv parseCLI sp = do
 -- @
 --
 runAppSubcommand
-  :: (HasColorOption options, HasVerboseOption options)
+  :: ( HasColorOption options
+     , HasVerboseOption options
+     , HasAutoSSOOption options
+     )
   => (subOptions -> AppT (App options) IO a)
   -> subOptions
   -> options

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Stackctl.Action
+      Stackctl.AutoSSO
       Stackctl.AWS
       Stackctl.AWS.CloudFormation
       Stackctl.AWS.Core
@@ -108,6 +109,7 @@ library
     , amazonka-core
     , amazonka-ec2
     , amazonka-lambda
+    , amazonka-sso
     , amazonka-sts
     , base ==4.*
     , bytestring
@@ -130,6 +132,7 @@ library
     , text
     , time
     , transformers
+    , typed-process
     , unliftio
     , unliftio-core
     , unordered-containers


### PR DESCRIPTION
When you run `stackctl` after your AWS SSO credentials have timed out, you see:

```
stackctl: ServiceError (ServiceError'
{ _serviceErrorAbbrev = Abbrev {fromAbbrev = "SSO"}
, _serviceErrorStatus = Status {statusCode = 401, statusMessage = "Unauthorized"}
, _serviceErrorHeaders = [("Date","Mon, 22 May 2023 17:56:45 GMT"),("Content-Type","application/json"),("Content-Length","114"),("Connection","keep-alive"),("Access-Control-Expose-Headers","RequestId"),("Access-Control-Expose-Headers","x-amzn-RequestId"),("RequestId","0763ba60-15ca-4fec-9b56-a329844f269d"),("Server","AWS SSO"),("x-amzn-RequestId","0763ba60-15ca-4fec-9b56-a329844f269d")]
, _serviceErrorCode = ErrorCode "Unauthorized"
, _serviceErrorMessage = Just (ErrorMessage {fromErrorMessage = "Session token not found or invalid"})
, _serviceErrorRequestId = Just (RequestId {fromRequestId = "0763ba60-15ca-4fec-9b56-a329844f269d"})
})
```

The solution is to (re)run `aws sso login` and try again.

This PR adds some handling for that exception. What it does depends on the `--auto-sso` option:

- `always`: logs a warning, runs `aws sso login` for you, then re-runs whatever you were trying to do
- `never`: logs an error and exits non-zero
- `ask`: (the default): logs a warning and prompts before behaving like `always`

Since this specifically uses `Amazonka.SSO.Types._Unauthorized` to catch the exception, I don't think it will have any effect on any other authorization errors.