### PR TITLE
Move to a different release action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+_Replace this content with your own_
+
+## Checklists
+
+### About the changes
+
+- [ ] Tests added if necessary
+- [ ] man-pages (`./man`) updated if necessary
+- [ ] Formatted properly (e.g. Restyled passes)
+
+### About the PR
+
+- [ ] Descriptive, imperative-tense title
+- [ ] Body explaining the _why_ of the change
+- [ ] `breaking-change` or `enhancement` label applied if appropriate

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: Features
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release executables
+name: Release
 
 on:
   push:
@@ -8,11 +8,9 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: tag
         uses: freckle/haskell-tag-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
 
@@ -21,23 +19,14 @@ jobs:
     if: needs.tag.outputs.tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - id: release-notes
-        uses: freckle/release-notes-action@v1
-        with:
-          version: ${{ needs.tag.outputs.tag }}
-      - uses: actions/create-release@v1
-        id: create-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - id: create-release
+        uses: freckle/action-gh-release@v2
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
-          release_name: Release ${{ needs.tag.outputs.tag }}
-          body_path: ${{ steps.release-notes.outputs.path }}
-          draft: false
-          prerelease: false
+          generate_release_notes: true
+          draft: true
     outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
+      release_id: ${{ steps.create-release.outputs.id }}
 
   upload-assets:
     needs: create-release
@@ -52,22 +41,31 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: freckle/stack-cache-action@v2
       - run: echo "$HOME/.local/share/gem/ruby/3.0.0/bin" >>"$GITHUB_PATH"
       - run: gem install --user ronn-ng
       - if: ${{ runner.os == 'macOS' }}
         run: brew install coreutils # need GNU install
-      - run: make install.check
-      - uses: actions/upload-release-asset@v1
-        id: upload-release-asset
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          make install.check # creates dist/stackctl.tar.gz
+          cp -v dist/stackctl.tar.gz stackctl-${{ matrix.suffix }}.tar.gz
+      - uses: freckle/action-gh-release@v2
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./dist/stackctl.tar.gz
-          asset_name: stackctl-${{ matrix.suffix }}.tar.gz
-          asset_content_type: application/gzip
+          id: ${{ needs.create-release.outputs.release_id }}
+          files: "*-${{ matrix.suffix }}.tar.gz"
+          fail_on_unmatched_files: true
+
+  publish-release:
+    needs:
+      - create-release
+      - upload-assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: freckle/action-gh-release@v2
+        with:
+          id: ${{ needs.create-release.outputs.release_id }}
+          draft: false
 
   upload-hackage:
     needs: tag


### PR DESCRIPTION
The way things were before we created a (pulished) release first, then
build and uploaded assets. This meant (particularly with OSX) the
release existed as "latest" for a long time without assets. This causes
issues for anyone that tries to install during this time, including some
test suites.

This new action allows you to create a Draft release, upload assets,
then publish it -- meaning it won't be visible until it's ready, solving
that problem.

Annoyingly, we had to fork the action to do it, as the best one our
there needed a fix and the maintainer is gone.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204659300478467