### PR TITLE
Cleanup and minor extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.4.2.2...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.4.3.0...main)
+
+## [v1.4.3.0](https://github.com/freckle/stackctl/compare/v1.4.2.2...v1.4.3.0)
+
+- Add `awsWithAuth`
+- Add `forEachSpec_`
 
 ## [v1.4.2.2](https://github.com/freckle/stackctl/compare/v1.4.2.1...v1.4.2.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.4.2.2
+version: 1.4.3.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/Spec/Changes.hs
+++ b/src/Stackctl/Spec/Changes.hs
@@ -76,9 +76,7 @@ runChanges ChangesOptions {..} = do
         Nothing -> pushLoggerLn formatted
         Just p -> liftIO $ T.appendFile p $ formatted <> "\n"
 
-  specs <- discoverSpecs
-
-  for_ specs $ \spec -> do
+  forEachSpec_ $ \spec -> do
     withThreadContext ["stackName" .= stackSpecStackName spec] $ do
       emChangeSet <- createChangeSet spec scoParameters scoTags
 

--- a/src/Stackctl/Spec/Deploy.hs
+++ b/src/Stackctl/Spec/Deploy.hs
@@ -88,9 +88,7 @@ runDeploy DeployOptions {..} = do
     removed <- inferRemovedStacks
     traverse_ (deleteRemovedStack sdoDeployConfirmation) removed
 
-  specs <- discoverSpecs
-
-  for_ specs $ \spec -> do
+  forEachSpec_ $ \spec -> do
     withThreadContext ["stackName" .= stackSpecStackName spec] $ do
       checkIfStackRequiresDeletion sdoDeployConfirmation
         $ stackSpecStackName spec

--- a/src/Stackctl/Spec/Discover.hs
+++ b/src/Stackctl/Spec/Discover.hs
@@ -1,5 +1,6 @@
 module Stackctl.Spec.Discover
-  ( discoverSpecs
+  ( forEachSpec_
+  , discoverSpecs
   , buildSpecPath
   ) where
 
@@ -16,6 +17,20 @@ import Stackctl.StackSpec
 import Stackctl.StackSpecPath
 import System.FilePath (isPathSeparator)
 import System.FilePath.Glob
+
+forEachSpec_
+  :: ( MonadMask m
+     , MonadResource m
+     , MonadLogger m
+     , MonadReader env m
+     , HasAwsScope env
+     , HasConfig env
+     , HasDirectoryOption env
+     , HasFilterOption env
+     )
+  => (StackSpec -> m ())
+  -> m ()
+forEachSpec_ f = traverse_ f =<< discoverSpecs
 
 discoverSpecs
   :: ( MonadMask m

--- a/src/Stackctl/Spec/List.hs
+++ b/src/Stackctl/Spec/List.hs
@@ -40,10 +40,9 @@ runList
   => ListOptions
   -> m ()
 runList _ = do
-  specs <- discoverSpecs
   Colors {..} <- getColorsLogger
 
-  for_ specs $ \spec -> do
+  forEachSpec_ $ \spec -> do
     let
       path = stackSpecFilePath spec
       name = stackSpecStackName spec

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.4.2.2
+version:        1.4.3.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues


### PR DESCRIPTION
### [Add forEachSpec_](https://github.com/freckle/stackctl/pull/53/commits/a29c109654c22fe327f73e91e0e17e8bbd2e1630)
[a29c109](https://github.com/freckle/stackctl/pull/53/commits/a29c109654c22fe327f73e91e0e17e8bbd2e1630)

### [Add awsWithAuth](https://github.com/freckle/stackctl/pull/53/commits/379d12af779b84e41949a8db76a8347941d3689a)
[379d12a](https://github.com/freckle/stackctl/pull/53/commits/379d12af779b84e41949a8db76a8347941d3689a)

This function allows access to the underlying `AuthEnv`. It's not used
by Stackctl (yet) but is used by tooling that uses Stackctl as its AWS
SDK wrapper to supply concrete keys to external processes that aren't
SSO-session aware.

In the future, this AWS "library" should be extracted and shared, but
for now we accept such minor extensions even if they only exist for
these external. use-cases.