### PR TITLE
Add awsSilently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.4.3.0...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.4.4.0...main)
+
+## [v1.4.4.0](https://github.com/freckle/stackctl/compare/v1.4.3.0...v1.4.4.0)
+
+- Add `awsSilently`
 
 ## [v1.4.3.0](https://github.com/freckle/stackctl/compare/v1.4.2.2...v1.4.3.0)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.4.3.0
+version: 1.4.4.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/AWS/CloudFormation.hs
+++ b/src/Stackctl/AWS/CloudFormation.hs
@@ -185,8 +185,10 @@ awsCloudFormationDescribeStackMaybe
 awsCloudFormationDescribeStackMaybe stackName =
   -- AWS gives us a 400 if the stackName doesn't exist, rather than simply
   -- returning an empty list, so we need to do this through exceptions
-  handling_ _ValidationError (pure Nothing) $ do
-    Just <$> awsCloudFormationDescribeStack stackName
+  handling_ _ValidationError (pure Nothing)
+    $ awsSilently -- don't log said 400
+    $ Just
+    <$> awsCloudFormationDescribeStack stackName
 
 awsCloudFormationDescribeStackOutputs
   :: (MonadResource m, MonadReader env m, HasAwsEnv env)

--- a/src/Stackctl/AWS/Core.hs
+++ b/src/Stackctl/AWS/Core.hs
@@ -12,6 +12,7 @@ module Stackctl.AWS.Core
     -- * Modifiers on 'AwsEnv'
   , awsWithin
   , awsTimeout
+  , awsSilently
 
     -- * 'Amazonka' extensions
   , AccountId (..)
@@ -173,6 +174,11 @@ awsWithin r = local $ awsEnvL . unL . env_region .~ r
 
 awsTimeout :: (MonadReader env m, HasAwsEnv env) => Seconds -> m a -> m a
 awsTimeout t = local $ over (awsEnvL . unL) (globalTimeout t)
+
+awsSilently :: (MonadReader env m, HasAwsEnv env) => m a -> m a
+awsSilently = local $ awsEnvL . unL . env_logger .~ noop
+ where
+  noop _level _msg = pure ()
 
 newtype AccountId = AccountId
   { unAccountId :: Text

--- a/src/Stackctl/AWS/Core.hs
+++ b/src/Stackctl/AWS/Core.hs
@@ -174,7 +174,7 @@ awsWithin :: (MonadReader env m, HasAwsEnv env) => Region -> m a -> m a
 awsWithin r = local $ awsEnvL . unL . env_region .~ r
 
 awsTimeout :: (MonadReader env m, HasAwsEnv env) => Seconds -> m a -> m a
-awsTimeout t = local $ over (awsEnvL . unL) (globalTimeout t)
+awsTimeout t = local $ awsEnvL . unL %~ globalTimeout t
 
 awsSilently :: (MonadReader env m, HasAwsEnv env) => m a -> m a
 awsSilently = local $ awsEnvL . unL . env_logger .~ noop

--- a/src/Stackctl/AWS/Core.hs
+++ b/src/Stackctl/AWS/Core.hs
@@ -40,6 +40,7 @@ import Conduit (ConduitM)
 import Control.Monad.Logger (defaultLoc, toLogStr)
 import Control.Monad.Trans.Resource (MonadResource)
 import Stackctl.AWS.Orphans ()
+import UnliftIO.Exception.Lens (handling)
 
 newtype AwsEnv = AwsEnv
   { unAwsEnv :: Env
@@ -191,7 +192,7 @@ newtype AccountId = AccountId
 -- makes things more readable and easier to debug.
 handlingServiceError :: (MonadUnliftIO m, MonadLogger m) => m a -> m a
 handlingServiceError =
-  handleJust @_ @SomeException (^? _ServiceError) $ \e -> do
+  handling _ServiceError $ \e -> do
     logError
       $ "Exiting due to AWS Service error"
       :# [ "code" .= toText (e ^. serviceError_code)

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.4.3.0
+version:        1.4.4.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues


### PR DESCRIPTION
This wrapper modifies the underlying `Env` to not log. This is useful to
avoid log noise when errors are expected (such as this not-found check),
since amazonka-2.0 logs certain errors that it didn't before, in
addition to throwing them.