### PR TITLE
Fix auto-expansion of filter option

### DIFF
--- a/src/Stackctl/FilterOption.hs
+++ b/src/Stackctl/FilterOption.hs
@@ -77,7 +77,7 @@ expandPatterns t = map compile $ s : expanded
 
   suffixed
     | "*" `T.isSuffixOf` t || hasExtension s = []
-    | otherwise = (s </> "*") : map (s <.>) extensions
+    | otherwise = (s </> "**" </> "*") : map (s <.>) extensions
 
   extensions = ["json", "yaml"]
 


### PR DESCRIPTION
Using (e.g.) `--filter progress` is meant to automatically find all
stacks related to this by turning that into a series of globs. Part of
that was turning it into `progress/**`, which is meant to find all
sub-directories. This was incorrect and needed to be `progress/**/*` for
that to work reliably. This small commit fixes that.
