### PR TITLE
Improve status indicators in stackctl-ls

### DIFF
--- a/man/stackctl-ls.1.ronn
+++ b/man/stackctl-ls.1.ronn
@@ -3,7 +3,7 @@ stackctl-ls(1) - list stack specifications
 
 ## SYNOPSIS
 
-`stackctl ls`
+`stackctl ls` [<options>]
 
 ## DESCRIPTION
 
@@ -11,9 +11,10 @@ This command locates `stacks/` for the currently-authorized AWS Account and
 Region and lists them.
 
 The key differences between this and stackctl-cat(1) is that this command lists
-things as simple rows and indicates for each spec if a deployed stack exists in
-the first column.
+things as simple rows and indicates for each spec the state of the stack in the
+first column.
 
 ## OPTIONS
 
-None.
+  * `--no-legend`:
+    Don't print indicators legend at the end.

--- a/src/Stackctl/AWS/CloudFormation.hs
+++ b/src/Stackctl/AWS/CloudFormation.hs
@@ -1,6 +1,7 @@
 module Stackctl.AWS.CloudFormation
   ( Stack (..)
   , stack_stackName
+  , stack_stackStatus
   , stackDescription
   , stackStatusRequiresDeletion
   , StackId (..)

--- a/src/Stackctl/Spec/List.hs
+++ b/src/Stackctl/Spec/List.hs
@@ -61,8 +61,6 @@ runList ListOptions {..} = do
       fmap (^. stack_stackStatus)
         <$> awsCloudFormationDescribeStackMaybe name
 
-    -- logInfo $ "" :# ["stackStatus" .= mStackStatus]
-
     let
       indicator = maybe NotDeployed statusIndicator mStackStatus
 

--- a/src/Stackctl/Spec/List.hs
+++ b/src/Stackctl/Spec/List.hs
@@ -7,6 +7,7 @@ module Stackctl.Spec.List
 import Stackctl.Prelude
 
 import Blammo.Logging.Logger (pushLoggerLn)
+import qualified Data.Text as T
 import Options.Applicative
 import Stackctl.AWS
 import Stackctl.AWS.Scope
@@ -17,12 +18,21 @@ import Stackctl.FilterOption (HasFilterOption)
 import Stackctl.Spec.Discover
 import Stackctl.StackSpec
 
-data ListOptions = ListOptions
-
--- brittany-disable-next-binding
+newtype ListOptions = ListOptions
+  { loLegend :: Bool
+  }
 
 parseListOptions :: Parser ListOptions
-parseListOptions = pure ListOptions
+parseListOptions =
+  ListOptions
+    <$> ( not
+            <$> switch
+              ( mconcat
+                  [ long "no-legend"
+                  , help "Don't print indicators legend at the end"
+                  ]
+              )
+        )
 
 runList
   :: ( MonadUnliftIO m
@@ -39,23 +49,76 @@ runList
      )
   => ListOptions
   -> m ()
-runList _ = do
-  Colors {..} <- getColorsLogger
+runList ListOptions {..} = do
+  colors@Colors {..} <- getColorsLogger
 
   forEachSpec_ $ \spec -> do
     let
       path = stackSpecFilePath spec
       name = stackSpecStackName spec
 
-    exists <- isJust <$> awsCloudFormationDescribeStackMaybe name
+    mStackStatus <-
+      fmap (^. stack_stackStatus)
+        <$> awsCloudFormationDescribeStackMaybe name
+
+    -- logInfo $ "" :# ["stackStatus" .= mStackStatus]
 
     let
+      indicator = maybe NotDeployed statusIndicator mStackStatus
+
       formatted :: Text
       formatted =
         "  "
-          <> (if exists then green "✓ " else yellow "✗ ")
+          <> indicatorIcon colors indicator
+          <> " "
           <> cyan (unStackName name)
           <> " => "
           <> magenta (pack path)
 
     pushLoggerLn formatted
+
+  let legendItem i = indicatorIcon colors i <> " " <> indicatorDescription i
+
+  when loLegend
+    $ pushLoggerLn
+    $ "\nLegend:\n  "
+    <> T.intercalate ", " (map legendItem [minBound .. maxBound])
+
+data Indicator
+  = Deployed
+  | DeployFailed
+  | NotDeployed
+  | Reviewing
+  | Deploying
+  | Unknown
+  deriving stock (Bounded, Enum)
+
+indicatorIcon :: Colors -> Indicator -> Text
+indicatorIcon Colors {..} = \case
+  Deployed -> green "✓"
+  DeployFailed -> red "✗"
+  NotDeployed -> yellow "_"
+  Reviewing -> yellow "∇"
+  Deploying -> cyan "⋅"
+  Unknown -> magenta "?"
+
+indicatorDescription :: Indicator -> Text
+indicatorDescription = \case
+  Deployed -> "deployed"
+  DeployFailed -> "failed or rolled back"
+  NotDeployed -> "doesn't exist"
+  Reviewing -> "reviewing"
+  Deploying -> "deploying"
+  Unknown -> "unknown"
+
+statusIndicator :: StackStatus -> Indicator
+statusIndicator = \case
+  StackStatus_REVIEW_IN_PROGRESS -> Reviewing
+  StackStatus_ROLLBACK_COMPLETE -> DeployFailed
+  x | statusSuffixed "_IN_PROGRESS" x -> Deploying
+  x | statusSuffixed "_FAILED" x -> DeployFailed
+  x | statusSuffixed "_ROLLBACK_COMPLETE" x -> DeployFailed
+  x | statusSuffixed "_COMPLETE" x -> Deployed
+  _ -> Unknown
+ where
+  statusSuffixed x = (x `T.isSuffixOf`) . fromStackStatus


### PR DESCRIPTION
![](https://files.pbrisbin.com/screenshots/screenshot.680981.png)

- Add more granularity

  A Stack that is not yet deployed at all may look deployed because it
  exists once the first change set is in review. Having a separate
  indication for this is valuable -- we might as well make more too.

- Print a legend at the end

  Now that we have more complicated indicators, showing what they mean
  seems valuable. A `--no-legend` option was added to suppress this, in
  case the output is being parsed line-wise.
