### PR TITLE
Simplify awsSimple

### DIFF
--- a/src/Stackctl/AWS/CloudFormation.hs
+++ b/src/Stackctl/AWS/CloudFormation.hs
@@ -176,7 +176,7 @@ awsCloudFormationDescribeStack
 awsCloudFormationDescribeStack stackName = do
   let req = newDescribeStacks & describeStacks_stackName ?~ unStackName stackName
 
-  awsSimple "DescribeStack" req $ \resp -> do
+  awsSimple req $ \resp -> do
     stacks <- resp ^. describeStacksResponse_stacks
     listToMaybe stacks
 
@@ -252,7 +252,7 @@ awsCloudFormationGetMostRecentStackEventId stackName = do
       [] -> Nothing
       (e : _) -> Just $ e ^. stackEvent_eventId
 
-  awsSimple "DescribeStackEvents" req
+  awsSimple req
     $ pure
     . getFirstEventId
     . fromMaybe []
@@ -268,7 +268,7 @@ awsCloudFormationDeleteStack stackName = do
     describeReq =
       newDescribeStacks & describeStacks_stackName ?~ unStackName stackName
 
-  awsSimple "DeleteStack" deleteReq $ const $ pure ()
+  awsSimple deleteReq $ const $ pure ()
 
   logDebug "Awaiting DeleteStack"
   stackDeleteResult <$> awsAwait newStackDeleteComplete describeReq
@@ -298,7 +298,7 @@ awsCloudFormationGetTemplate stackName = do
     decodeTemplateBody body =
       fromMaybe (toJSON body) $ decodeStrict $ encodeUtf8 body
 
-  awsSimple "GetTemplate" req $ \resp -> do
+  awsSimple req $ \resp -> do
     body <- resp ^. getTemplateResponse_templateBody
     pure $ decodeTemplateBody body
 
@@ -409,7 +409,7 @@ awsCloudFormationCreateChangeSet stackName mStackDescription stackTemplate param
       logInfo
         $ "Creating changeset..."
         :# ["name" .= name, "type" .= changeSetType]
-      csId <- awsSimple "CreateChangeSet" req (^. createChangeSetResponse_id)
+      csId <- awsSimple req (^. createChangeSetResponse_id)
 
       logDebug "Awaiting CREATE_COMPLETE"
       void $ awsAwait newChangeSetCreateComplete $ newDescribeChangeSet csId
@@ -424,7 +424,7 @@ awsCloudFormationDescribeChangeSet
   -> m ChangeSet
 awsCloudFormationDescribeChangeSet changeSetId = do
   let req = newDescribeChangeSet $ unChangeSetId changeSetId
-  awsSimple "DescribeChangeSet" req changeSetFromResponse
+  awsSimple req changeSetFromResponse
 
 sortChanges :: [Change] -> [Change]
 sortChanges = sortByDependencies changeName changeCausedBy

--- a/src/Stackctl/AWS/EC2.hs
+++ b/src/Stackctl/AWS/EC2.hs
@@ -12,7 +12,7 @@ awsEc2DescribeFirstAvailabilityZoneRegionName
   :: (MonadResource m, MonadReader env m, HasAwsEnv env) => m Region
 awsEc2DescribeFirstAvailabilityZoneRegionName = do
   let req = newDescribeAvailabilityZones
-  awsSimple "DescribeAvailabilityZones" req $ \resp -> do
+  awsSimple req $ \resp -> do
     azs <- resp ^. describeAvailabilityZonesResponse_availabilityZones
     az <- listToMaybe azs
     rn <- regionName az

--- a/src/Stackctl/AWS/STS.hs
+++ b/src/Stackctl/AWS/STS.hs
@@ -10,5 +10,5 @@ import Stackctl.AWS.Core
 awsGetCallerIdentityAccount
   :: (MonadResource m, MonadReader env m, HasAwsEnv env) => m AccountId
 awsGetCallerIdentityAccount = do
-  awsSimple "GetCallerIdentity" newGetCallerIdentity $ \resp -> do
+  awsSimple newGetCallerIdentity $ \resp -> do
     AccountId <$> resp ^. getCallerIdentityResponse_account


### PR DESCRIPTION
Amazonka-2.0 adds a `Typeable` constraint to its `send`-et-al functions,
presumably because it's using `typeRep` to render the type of response
in its own logging. This means we too can use `typeRep` for our own
error message in `awsSimple` and thus not need to pass in an argument
for that.

Passing this argument was always an annoying bit of boilerplate and
subject to inconsistencies (sometimes we'd prefix with the service,
sometimes not, for example). This is more convenient and consistent. The
only downsides are churn for callers and requiring a major version bump,
which is acceptable.
