### PR TITLE
OneOrListOf, Exec & Shell constructors for ActionRun

### DIFF
--- a/man/stackctl.1.ronn
+++ b/man/stackctl.1.ronn
@@ -124,12 +124,21 @@ And these constituent parts are used as follows:
     **PostDeploy**: run the action after a successful deployment.
 
   * `{.Actions[].run}`:
-    The action to perform on the given event:
+    An action or list of actions to perform on the given event:
 
     **InvokeLambdaByStackOutput**: <output name>: invoke the function whose name
     is found in the given Output of the deployed Stack.
 
     **InvokeLambdaByName**: <function name>: invoke the given function.
+
+    **Exec**: [<command>, <argument...>]: execute the given `command` and
+    `argument`s.
+
+    **Shell**: <argument>: execute the given argument via `sh -c`.
+
+    Executed processes will inherit any environment variables and print their
+    own `stdout` and `stderr`. If they do not exit 0, an exception is thrown and
+    `stackctl` itself exits.
 
   * `{.Parameters}`:
     Optional. Parameters to use when deploying the Stack.

--- a/src/Stackctl/OneOrListOf.hs
+++ b/src/Stackctl/OneOrListOf.hs
@@ -1,0 +1,56 @@
+module Stackctl.OneOrListOf
+  ( OneOrListOf
+  , fromList
+  ) where
+
+import Stackctl.Prelude
+
+import Data.Aeson
+
+-- | Type representing one @a@ or a list of @a@
+--
+-- This type is isomorphic both @'NonEmpty' a@ and @'Either' a [a]@. Its primary
+-- use-case is to parse Yaml (through its 'FromJSON') where users may specify a
+-- list of values, but specifying a single value is worth supporting, typically
+-- for backwards-compatibility:
+--
+-- @
+-- something:
+--   field:
+--     - one
+--     - two
+--
+-- something:
+--   field: one # => should be treated like field: [one]
+-- @
+--
+-- The 'Foldable' instance should be used to treat the value like a list, such
+-- as extracting it directly via 'toList'.
+--
+-- Implementation note: this type preserves the form in which it was decoded (in
+-- other words, it's not a @newtype@ over one of the isomorphic types mentioned
+-- above), so that we can encode it back out in the same format.
+data OneOrListOf a = One a | List [a]
+  deriving stock (Eq, Show, Generic, Foldable)
+
+fromList :: [a] -> OneOrListOf a
+fromList = List
+
+instance Semigroup (OneOrListOf a) where
+  One a <> One b = List [a, b]
+  One a <> List bs = List $ a : bs
+  List as <> One b = List $ as <> [b]
+  List as <> List bs = List $ as <> bs
+
+instance FromJSON a => FromJSON (OneOrListOf a) where
+  parseJSON = \case
+    Array xs -> List . toList <$> traverse parseJSON xs
+    v -> One <$> parseJSON v
+
+instance ToJSON a => ToJSON (OneOrListOf a) where
+  toJSON = \case
+    One a -> toJSON a
+    List as -> toJSON as
+  toEncoding = \case
+    One a -> toEncoding a
+    List as -> toEncoding as

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -43,6 +43,7 @@ library
       Stackctl.Config.RequiredVersion
       Stackctl.DirectoryOption
       Stackctl.FilterOption
+      Stackctl.OneOrListOf
       Stackctl.Options
       Stackctl.ParameterOption
       Stackctl.Prelude
@@ -185,6 +186,7 @@ test-suite spec
       Stackctl.Config.RequiredVersionSpec
       Stackctl.ConfigSpec
       Stackctl.FilterOptionSpec
+      Stackctl.OneOrListOfSpec
       Stackctl.Spec.Changes.FormatSpec
       Stackctl.StackDescriptionSpec
       Stackctl.StackSpecSpec

--- a/test/Stackctl/OneOrListOfSpec.hs
+++ b/test/Stackctl/OneOrListOfSpec.hs
@@ -1,0 +1,47 @@
+module Stackctl.OneOrListOfSpec
+  ( spec
+  ) where
+
+import Stackctl.Prelude
+
+import Data.Aeson
+import qualified Data.Yaml as Yaml
+import Stackctl.OneOrListOf
+import Test.Hspec
+
+data ExampleObject = ExampleObject
+  { oneOf :: OneOrListOf Text
+  , listOf :: OneOrListOf Text
+  }
+  deriving stock (Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- N.B. the sorting and indentation must match what encode will do in order for
+-- the round-trip spec to pass.
+exampleBS :: ByteString
+exampleBS =
+  mconcat
+    [ "listOf:\n"
+    , "- one\n"
+    , "- two\n"
+    , "oneOf: one\n"
+    ]
+
+spec :: Spec
+spec = do
+  it "Foldable" $ do
+    ExampleObject {..} <- Yaml.decodeThrow exampleBS
+
+    toList oneOf `shouldBe` ["one"]
+
+    toList listOf `shouldBe` ["one", "two"]
+
+  it "Semigroup" $ do
+    ExampleObject {..} <- Yaml.decodeThrow exampleBS
+
+    toList (oneOf <> listOf) `shouldBe` ["one", "one", "two"]
+
+  it "From/ToJSON" $ do
+    decoded <- Yaml.decodeThrow @_ @ExampleObject exampleBS
+
+    Yaml.encode decoded `shouldBe` exampleBS

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -24,7 +24,7 @@ spec = do
               , ssyDepends = Just [StackName "a-stack", StackName "another-stack"]
               , ssyActions =
                   Just
-                    [newAction PostDeploy $ InvokeLambdaByName "a-lambda"]
+                    [newAction PostDeploy [InvokeLambdaByName "a-lambda"]]
               , ssyParameters =
                   Just
                     $ parametersYaml


### PR DESCRIPTION
[This RFC](https://renaissancelearning.atlassian.net/wiki/spaces/OPS/pages/42982703270/Stackctl+Actions+PlatformCLI+Run) (Freckle-private wiki) explains the broader plan for using
this. Since the first part of the plan wasn't really optional, I've
implemented that far here.

### [Add OneOrListOf, use for Action{run}](https://github.com/freckle/stackctl/pull/60/commits/938db472d1d5696ca843bdc8e2e28fe0ccbedfe5)
[938db47](https://github.com/freckle/stackctl/pull/60/commits/938db472d1d5696ca843bdc8e2e28fe0ccbedfe5)

Sometimes it's useful to do more than one thing on an event, such as
create and migrate the DB on post-deploy of a DB-related resource.

Specifying a list for `run` is simpler, with more obvious semantics,
than specifying multiple actions with the same `on`. However, to avoid
breaking existing specifications specifying a single item for `run`
should still be supported.

The `OneOrListOf` wrapper implements parsing such values either way
either. And it's `Foldable` instance makes usage very nice. The
`Semigroup` instance is not currently used, so I'm open to removing it,
but it seemed reasonable to include.

### [Add Exec and Shell to ActionRun constructors](https://github.com/freckle/stackctl/pull/60/commits/57e66c320a98839b8f119ef3e0f874b0b6008528)
[57e66c3](https://github.com/freckle/stackctl/pull/60/commits/57e66c320a98839b8f119ef3e0f874b0b6008528)

This can be used to execute an arbitrary process on events such as
`PostDeploy`. The distinct constructors (vs parsing differently to a
single constructor) are used to ensure that our Yaml round-trips
faithfully.