### PR TITLE
Add warning if specs depend on unknown specs

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -90,6 +90,7 @@ library:
     - rio
     - semigroups
     - text
+    - text-metrics
     - time
     - transformers
     - typed-process

--- a/src/Stackctl/StackSpec.hs
+++ b/src/Stackctl/StackSpec.hs
@@ -5,6 +5,7 @@ module Stackctl.StackSpec
   , stackSpecSpecBody
   , stackSpecStackName
   , stackSpecStackDescription
+  , stackSpecDepends
   , stackSpecActions
   , stackSpecParameters
   , stackSpecCapabilities

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -130,6 +130,7 @@ library
     , rio
     , semigroups
     , text
+    , text-metrics
     , time
     , transformers
     , typed-process


### PR DESCRIPTION
It's a common typo to add a stack in `Depends` that doesn't actually
exist. When this happens, everything still "works", except multi-stack
deploys may not order correctly.

We'll now check for this and emit a warning. It may be better as a fatal
error (I'm not sure I can come up with a real use-case for depending on
a stack not also managed in this same set of specifications), but I'm
starting out conservatively for now.

![Example](https://files.pbrisbin.com/screenshots/screenshot.667322.png)
