### PR TITLE
Use requiredVersionToText in logged warning

### DIFF
--- a/src/Stackctl/Config.hs
+++ b/src/Stackctl/Config.hs
@@ -63,7 +63,8 @@ configErrorMessage = \case
       :# ["error" .= Yaml.prettyPrintParseException ex]
   ConfigInvalid errs -> "Invalid configuration" :# ["errors" .= errs]
   ConfigVersionNotSatisfied rv v ->
-    "Incompatible Stackctl version" :# ["current" .= v, "required" .= show rv]
+    "Incompatible Stackctl version"
+      :# ["current" .= v, "required" .= show (requiredVersionToText rv)]
 
 loadConfigOrExit :: (MonadIO m, MonadLogger m) => m Config
 loadConfigOrExit = either die pure =<< loadConfig


### PR DESCRIPTION
Before, this warning looked like:

```
2023-09-28 14:39:53 [error    ] Incompatible Stackctl version
                                current=1.5.0.0
                                required=RequiredVersion {requiredVersionOp = RequiredVersionIsh, requiredVersionCompareWith = Version {versionBranch = [1,4], versionTags = []}}
```

Now, it looks like:

```
2023-09-28 14:40:11 [error    ] Incompatible Stackctl version   current=1.5.0.0 required="=~ 1.4"
```

NOTE: the `show` may seem redundant now, but it was kept to make the
value come out quoted (and escaped, if that's ever necessary).
