### PR TITLE
Add tests using Control.Monad.AWS.ViaMock

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -120,6 +120,7 @@ tests:
       - Glob
       - QuickCheck
       - aeson
+      - amazonka-cloudformation
       - amazonka-ec2
       - amazonka-lambda
       - amazonka-mtl

--- a/package.yaml
+++ b/package.yaml
@@ -116,13 +116,18 @@ tests:
     main: Spec.hs
     source-dirs: test
     dependencies:
+      - Blammo
       - Glob
       - QuickCheck
       - aeson
+      - amazonka-ec2
+      - amazonka-mtl
       - bytestring
       - filepath
       - hspec
+      - hspec-expectations-lifted
       - hspec-golden >= 0.2.1.0
+      - lens
       - mtl
       - stackctl
       - yaml

--- a/package.yaml
+++ b/package.yaml
@@ -121,6 +121,7 @@ tests:
       - QuickCheck
       - aeson
       - amazonka-ec2
+      - amazonka-lambda
       - amazonka-mtl
       - bytestring
       - filepath

--- a/src/Stackctl/AWS/Lambda.hs
+++ b/src/Stackctl/AWS/Lambda.hs
@@ -60,7 +60,7 @@ data LambdaError = LambdaError
   , errorMessage :: Text
   , trace :: [Text]
   }
-  deriving stock (Show, Generic)
+  deriving stock (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 awsLambdaInvoke

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -231,6 +231,7 @@ test-suite spec
     , Glob
     , QuickCheck
     , aeson
+    , amazonka-cloudformation
     , amazonka-ec2
     , amazonka-lambda
     , amazonka-mtl

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -185,6 +185,7 @@ test-suite spec
   other-modules:
       Stackctl.AWS.CloudFormationSpec
       Stackctl.AWS.EC2Spec
+      Stackctl.AWS.LambdaSpec
       Stackctl.AWS.ScopeSpec
       Stackctl.Config.RequiredVersionSpec
       Stackctl.ConfigSpec
@@ -231,6 +232,7 @@ test-suite spec
     , QuickCheck
     , aeson
     , amazonka-ec2
+    , amazonka-lambda
     , amazonka-mtl
     , base ==4.*
     , bytestring

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -184,6 +184,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Stackctl.AWS.CloudFormationSpec
+      Stackctl.AWS.EC2Spec
       Stackctl.AWS.ScopeSpec
       Stackctl.Config.RequiredVersionSpec
       Stackctl.ConfigSpec
@@ -193,6 +194,7 @@ test-suite spec
       Stackctl.StackDescriptionSpec
       Stackctl.StackSpecSpec
       Stackctl.StackSpecYamlSpec
+      Stackctl.Test.App
       Paths_stackctl
   hs-source-dirs:
       test
@@ -224,14 +226,19 @@ test-suite spec
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
-      Glob
+      Blammo
+    , Glob
     , QuickCheck
     , aeson
+    , amazonka-ec2
+    , amazonka-mtl
     , base ==4.*
     , bytestring
     , filepath
     , hspec
+    , hspec-expectations-lifted
     , hspec-golden >=0.2.1.0
+    , lens
     , mtl
     , stackctl
     , yaml

--- a/test/Stackctl/AWS/CloudFormationSpec.hs
+++ b/test/Stackctl/AWS/CloudFormationSpec.hs
@@ -2,27 +2,95 @@ module Stackctl.AWS.CloudFormationSpec
   ( spec
   ) where
 
-import Stackctl.Prelude
+import Stackctl.Test.App
 
+import Amazonka.CloudFormation.DeleteChangeSet
+import Amazonka.CloudFormation.ListChangeSets
+import Amazonka.CloudFormation.Types.ChangeSetSummary
+import Blammo.Logging.Logger (LoggedMessage (..), getLoggedMessagesUnsafe)
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.List (isSuffixOf)
 import Stackctl.AWS.CloudFormation
-import Test.Hspec
 
 spec :: Spec
 spec = do
   describe "readParameter" $ do
-    it "refuses empty key" $ do
+    it "refuses empty key" $ example $ do
       readParameter "=Value"
         `shouldSatisfy` either ("empty KEY" `isSuffixOf`) (const False)
 
-    it "refuses empty value" $ do
+    it "refuses empty value" $ example $ do
       readParameter "Key"
         `shouldSatisfy` either ("empty VALUE" `isSuffixOf`) (const False)
 
-    it "refuses empty value (with =)" $ do
+    it "refuses empty value (with =)" $ example $ do
       readParameter "Key="
         `shouldSatisfy` either ("empty VALUE" `isSuffixOf`) (const False)
 
-    it "creates a parameter when valid" $ do
+    it "creates a parameter when valid" $ example $ do
       readParameter "Key=Value=More"
         `shouldBe` Right (makeParameter "Key" $ Just "Value=More")
+
+  describe "awsCloudFormationDeleteAllChangeSets" $ do
+    it "deletes all listed changesets" $ example $ runTestAppT $ do
+      let
+        stackName :: Text
+        stackName = "some-stack"
+
+        cs1 :: Text
+        cs1 = "some-changeset-1"
+
+        cs2 :: Text
+        cs2 = "some-changeset-2"
+
+        cs3 :: Text
+        cs3 = "some-changeset-3"
+
+        isListChangeSetsPage :: Maybe Text -> ListChangeSets -> Bool
+        isListChangeSetsPage p req =
+          and
+            [ req ^. listChangeSets_stackName == stackName
+            , req ^. listChangeSets_nextToken == p
+            ]
+
+        isDeleteChangeSet :: Text -> DeleteChangeSet -> Bool
+        isDeleteChangeSet cs req = req ^. deleteChangeSet_changeSetName == cs
+
+        summary1 = newChangeSetSummary & changeSetSummary_changeSetId ?~ cs1
+        summary2 = newChangeSetSummary & changeSetSummary_changeSetId ?~ cs2
+        summary3 = newChangeSetSummary & changeSetSummary_changeSetId ?~ cs3
+
+        matchers =
+          [ SendMatcher (isListChangeSetsPage Nothing)
+              $ Right
+              $ newListChangeSetsResponse 200
+              & (listChangeSetsResponse_summaries ?~ [summary1, summary2])
+              & (listChangeSetsResponse_nextToken ?~ "p2")
+          , SendMatcher (isListChangeSetsPage $ Just "p2")
+              $ Right
+              $ newListChangeSetsResponse 200
+              & (listChangeSetsResponse_summaries ?~ [summary3])
+          , SendMatcher (isDeleteChangeSet cs1)
+              $ Right
+              $ newDeleteChangeSetResponse 200
+          , SendMatcher (isDeleteChangeSet cs2)
+              $ Right
+              $ newDeleteChangeSetResponse 200
+          , SendMatcher (isDeleteChangeSet cs3)
+              $ Right
+              $ newDeleteChangeSetResponse 200
+          ]
+
+      withMatchers matchers $ do
+        awsCloudFormationDeleteAllChangeSets $ StackName stackName
+
+        messages <-
+          map (loggedMessageText &&& loggedMessageMeta)
+            <$> getLoggedMessagesUnsafe
+
+        messages
+          `shouldBe` [ ("Deleting all changesets", mempty)
+                     , ("Enqueing delete", KeyMap.fromList [("changeSetId", toJSON cs1)])
+                     , ("Enqueing delete", KeyMap.fromList [("changeSetId", toJSON cs2)])
+                     , ("Enqueing delete", KeyMap.fromList [("changeSetId", toJSON cs3)])
+                     ]

--- a/test/Stackctl/AWS/EC2Spec.hs
+++ b/test/Stackctl/AWS/EC2Spec.hs
@@ -1,0 +1,29 @@
+module Stackctl.AWS.EC2Spec
+  ( spec
+  ) where
+
+import Stackctl.Test.App
+
+import Amazonka.EC2.DescribeAvailabilityZones
+import Amazonka.EC2.Types.AvailabilityZone
+import Stackctl.AWS.EC2
+
+spec :: Spec
+spec = do
+  describe "awsEc2DescribeFirstAvailabilityZoneRegionName" $ do
+    it "returns the first AZ's region name" $ example $ runTestAppT $ do
+      let
+        zones =
+          [ newAvailabilityZone & availabilityZone_regionName ?~ "us-east-1"
+          , newAvailabilityZone & availabilityZone_regionName ?~ "us-east-2"
+          , newAvailabilityZone & availabilityZone_regionName ?~ "us-west-1"
+          ]
+        matcher =
+          SendMatcher (const @_ @DescribeAvailabilityZones True)
+            $ Right
+            $ newDescribeAvailabilityZonesResponse 200
+            & describeAvailabilityZonesResponse_availabilityZones
+            ?~ zones
+
+      withMatcher matcher awsEc2DescribeFirstAvailabilityZoneRegionName
+        `shouldReturn` "us-east-1"

--- a/test/Stackctl/AWS/LambdaSpec.hs
+++ b/test/Stackctl/AWS/LambdaSpec.hs
@@ -1,0 +1,65 @@
+module Stackctl.AWS.LambdaSpec
+  ( spec
+  ) where
+
+import Stackctl.Test.App
+
+import Amazonka.Lambda.Invoke
+import Data.Aeson
+import qualified Data.ByteString.Lazy as BSL
+import Stackctl.AWS.Lambda
+
+spec :: Spec
+spec = do
+  describe "awsLambdaInvoke" $ do
+    it "invokes a lambda" $ example $ runTestAppT $ do
+      let
+        emptyObject = object []
+
+        isInvocation name invoke =
+          and
+            [ invoke ^. invoke_functionName == name
+            , invoke ^. invoke_payload == "{}"
+            ]
+
+        lambdaError =
+          LambdaError
+            { errorType = "exception"
+            , errorMessage = "oops"
+            , trace = []
+            }
+
+        matchers =
+          [ SendMatcher (isInvocation "lambda-1")
+              $ Right
+              $ newInvokeResponse 200
+              & invokeResponse_payload
+              ?~ "<response>"
+          , SendMatcher (isInvocation "lambda-2")
+              $ Right
+              $ newInvokeResponse 200
+              & invokeResponse_payload
+              ?~ BSL.toStrict (encode lambdaError)
+          , SendMatcher (isInvocation "lambda-3")
+              $ Right
+              $ newInvokeResponse 500
+              & (invokeResponse_payload ?~ "<response>")
+              . (invokeResponse_functionError ?~ "<error>")
+          ]
+
+      withMatchers matchers $ do
+        LambdaInvokeSuccess successPayload <-
+          awsLambdaInvoke "lambda-1" emptyObject
+
+        successPayload `shouldBe` "<response>"
+
+        LambdaInvokeError errorPayload _ <-
+          awsLambdaInvoke "lambda-2" emptyObject
+
+        errorPayload `shouldBe` lambdaError
+
+        LambdaInvokeFailure failureStatus failureFunctionError <-
+          awsLambdaInvoke "lambda-3" emptyObject
+
+        failureStatus `shouldBe` 500
+        failureFunctionError `shouldBe` Just "<error>"

--- a/test/Stackctl/Test/App.hs
+++ b/test/Stackctl/Test/App.hs
@@ -44,6 +44,9 @@ newtype TestAppT m a = TestAppT
     )
   deriving (MonadAWS) via (MockAWS (TestAppT m))
 
+instance MonadIO m => MonadFail (TestAppT m) where
+  fail msg = expectationFailure msg >> error "unreachable"
+
 runTestAppT :: MonadUnliftIO m => TestAppT m a -> m a
 runTestAppT f = do
   app <-

--- a/test/Stackctl/Test/App.hs
+++ b/test/Stackctl/Test/App.hs
@@ -1,0 +1,54 @@
+module Stackctl.Test.App
+  ( TestAppT
+  , runTestAppT
+
+    -- * Re-exports
+  , module Stackctl.Prelude
+  , module Control.Lens
+  , module Control.Monad.AWS.ViaMock
+  , module Test.Hspec
+  , module Test.Hspec.Expectations.Lifted
+  ) where
+
+import Stackctl.Prelude
+
+import Blammo.Logging.Logger (newTestLogger)
+import Control.Lens ((?~))
+import Control.Monad.AWS
+import Control.Monad.AWS.ViaMock
+import Test.Hspec (Spec, describe, example, it)
+import Test.Hspec.Expectations.Lifted
+
+data TestApp = TestApp
+  { taLogger :: Logger
+  , taMatchers :: Matchers
+  }
+
+instance HasLogger TestApp where
+  loggerL = lens taLogger $ \x y -> x {taLogger = y}
+
+instance HasMatchers TestApp where
+  matchersL = lens taMatchers $ \x y -> x {taMatchers = y}
+
+newtype TestAppT m a = TestAppT
+  { unTestAppT :: ReaderT TestApp (LoggingT m) a
+  }
+  deriving newtype
+    ( Functor
+    , Applicative
+    , Monad
+    , MonadIO
+    , MonadUnliftIO
+    , MonadLogger
+    , MonadReader TestApp
+    )
+  deriving (MonadAWS) via (MockAWS (TestAppT m))
+
+runTestAppT :: MonadUnliftIO m => TestAppT m a -> m a
+runTestAppT f = do
+  app <-
+    TestApp
+      <$> newTestLogger defaultLogSettings
+      <*> pure mempty
+
+  runLoggerLoggingT app $ runReaderT (unTestAppT f) app


### PR DESCRIPTION
### [Add basics of aws test machinery](https://github.com/freckle/stackctl/pull/68/commits/541d69f502d408951f3476475ae31616e9974a0a)
[541d69f](https://github.com/freckle/stackctl/pull/68/commits/541d69f502d408951f3476475ae31616e9974a0a)

Use it to test a simple AWS-calling function.

### [Add spec on Lambda invocations](https://github.com/freckle/stackctl/pull/68/commits/72ba036596cf62adc4d1989c56549265e8545878)
[72ba036](https://github.com/freckle/stackctl/pull/68/commits/72ba036596cf62adc4d1989c56549265e8545878)

This shows using multiple matchers on the same type of request. It also
motivated a useful `MonadFail` instance for pattern matches within
`TestAppT`.

### [Test awsCloudFormationDeleteChangeSets](https://github.com/freckle/stackctl/pull/68/commits/5cf7696b098682a9661c031b8c730032e9b80c1a)
[5cf7696](https://github.com/freckle/stackctl/pull/68/commits/5cf7696b098682a9661c031b8c730032e9b80c1a)

This exercises matching different types of requests, including paginated
requests, in the same test. It also shows asserting what messages were
logged.