### PR TITLE
Respect STACKCTL_DIRECTORY in findRemovedStack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.6.1.0...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.6.1.1...main)
+
+## [v1.6.1.1](https://github.com/freckle/stackctl/compare/v1.6.1.0...v1.6.1.1)
+
+- Fix: finding removed stacks now respects `STACKCTL_DIRECTORY`
 
 ## [v1.6.1.0](https://github.com/freckle/stackctl/compare/v1.6.0.0...v1.6.1.0)
 

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -12,4 +12,9 @@ in-style: left-align
 single-constraint-parens: never # ignored until v12 / ghc-9.6
 unicode: never # default
 respectful: true # default
-fixities: [] # default
+
+# fourmolu can't figure this out because of the re-exports we use
+fixities:
+  - "infixl 1 &"
+  - "infixr 4 .~"
+  - "infixr 4 ?~"

--- a/package.yaml
+++ b/package.yaml
@@ -136,4 +136,5 @@ tests:
       - stackctl
       - text
       - time
+      - unliftio
       - yaml

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.6.1.0
+version: 1.6.1.1
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/package.yaml
+++ b/package.yaml
@@ -120,6 +120,7 @@ tests:
       - Glob
       - QuickCheck
       - aeson
+      - amazonka
       - amazonka-cloudformation
       - amazonka-ec2
       - amazonka-lambda
@@ -129,7 +130,10 @@ tests:
       - hspec
       - hspec-expectations-lifted
       - hspec-golden >= 0.2.1.0
+      - http-types
       - lens
       - mtl
       - stackctl
+      - text
+      - time
       - yaml

--- a/src/Stackctl/RemovedStack.hs
+++ b/src/Stackctl/RemovedStack.hs
@@ -9,6 +9,7 @@ import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Stackctl.AWS.CloudFormation
 import Stackctl.AWS.Core as AWS
 import Stackctl.AWS.Scope
+import Stackctl.DirectoryOption
 import Stackctl.FilterOption
 import UnliftIO.Directory (doesFileExist)
 
@@ -17,26 +18,30 @@ inferRemovedStacks
      , MonadAWS m
      , MonadReader env m
      , HasAwsScope env
+     , HasDirectoryOption env
      , HasFilterOption env
      )
   => m [Stack]
 inferRemovedStacks = do
   scope <- view awsScopeL
   paths <- view $ filterOptionL . to filterOptionToPaths
-  catMaybes <$> traverse (findRemovedStack scope) paths
+  dir <- view $ directoryOptionL . to unDirectoryOption
+  catMaybes <$> traverse (findRemovedStack scope dir) paths
 
 findRemovedStack
   :: (MonadUnliftIO m, MonadAWS m)
   => AwsScope
   -> FilePath
+  -- ^ Root directory
+  -> FilePath
   -> m (Maybe Stack)
-findRemovedStack scope path = runMaybeT $ do
+findRemovedStack scope dir path = runMaybeT $ do
   -- The filter is a full path to a specification in the current
   -- account/region...
   stackName <- hoistMaybe $ awsScopeSpecStackName scope path
 
   -- that no longer exists...
-  guard . not =<< doesFileExist path
+  guard . not =<< doesFileExist (dir </> path)
 
   -- but the Stack it would point to does
   MaybeT $ awsCloudFormationDescribeStackMaybe stackName

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -191,6 +191,7 @@ test-suite spec
       Stackctl.ConfigSpec
       Stackctl.FilterOptionSpec
       Stackctl.OneOrListOfSpec
+      Stackctl.RemovedStackSpec
       Stackctl.Spec.Changes.FormatSpec
       Stackctl.StackDescriptionSpec
       Stackctl.StackSpecSpec
@@ -231,6 +232,7 @@ test-suite spec
     , Glob
     , QuickCheck
     , aeson
+    , amazonka
     , amazonka-cloudformation
     , amazonka-ec2
     , amazonka-lambda
@@ -241,8 +243,11 @@ test-suite spec
     , hspec
     , hspec-expectations-lifted
     , hspec-golden >=0.2.1.0
+    , http-types
     , lens
     , mtl
     , stackctl
+    , text
+    , time
     , yaml
   default-language: Haskell2010

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.6.1.0
+version:        1.6.1.1
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -249,5 +249,6 @@ test-suite spec
     , stackctl
     , text
     , time
+    , unliftio
     , yaml
   default-language: Haskell2010

--- a/test/Stackctl/RemovedStackSpec.hs
+++ b/test/Stackctl/RemovedStackSpec.hs
@@ -1,0 +1,80 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+module Stackctl.RemovedStackSpec
+  ( spec
+  ) where
+
+import Stackctl.Test.App
+
+import qualified Amazonka
+import qualified Amazonka.CloudFormation as CloudFormation
+import Amazonka.CloudFormation.DescribeStacks
+import Amazonka.CloudFormation.Types.Stack
+import qualified Data.Text as T
+import Data.Time (UTCTime (..))
+import Data.Time.Calendar (DayOfMonth, MonthOfYear, Year, fromGregorian)
+import Network.HTTP.Types.Status (status400)
+import Stackctl.AWS.CloudFormation
+import Stackctl.FilterOption (filterOptionFromText, filterOptionL)
+import Stackctl.RemovedStack
+
+spec :: Spec
+spec = do
+  describe "inferRemovedStacks" $ do
+    it "returns stacks in filters that aren't on disk" $ example $ runTestAppT $ do
+      let
+        Just filterOption =
+          filterOptionFromText
+            $ T.intercalate
+              ","
+              [ pack $ testAppStackFilePath "stack-exists"
+              , pack $ testAppStackFilePath "stack-is-missing"
+              , "stacks/0123456789.test/us-east-2/wrong-region.yaml"
+              , "stacks/2123456789.test/us-east-1/wrong-account.yaml"
+              ]
+
+        setup :: TestApp -> TestApp
+        setup = filterOptionL .~ filterOption
+
+        matchers =
+          [ describeStackMatcher "stack-exists" $ Just $ someStack "stack-exists"
+          , describeStackMatcher "stack-is-missing" Nothing
+          , describeStackMatcher "wrong-region" Nothing
+          , describeStackMatcher "wrong-account" Nothing
+          ]
+
+      stacks <- local setup $ withMatchers matchers inferRemovedStacks
+      map (^. stack_stackName) stacks `shouldBe` ["stack-exists"]
+
+describeStackMatcher :: Text -> Maybe Stack -> Matcher
+describeStackMatcher name =
+  SendMatcher ((== Just name) . (^. describeStacks_stackName))
+    . maybe
+      (Left cloudFormationValidationError)
+      ( \stack ->
+          Right
+            $ newDescribeStacksResponse 200
+            & describeStacksResponse_stacks ?~ [stack]
+      )
+
+someStack :: Text -> Stack
+someStack name = newStack name (midnight 2024 1 1) StackStatus_CREATE_COMPLETE
+
+midnight :: Year -> MonthOfYear -> DayOfMonth -> UTCTime
+midnight y m d =
+  UTCTime
+    { utctDay = fromGregorian y m d
+    , utctDayTime = 0
+    }
+
+cloudFormationValidationError :: Amazonka.Error
+cloudFormationValidationError =
+  Amazonka.ServiceError
+    $ Amazonka.ServiceError'
+      { Amazonka.abbrev = CloudFormation.defaultService ^. Amazonka.service_abbrev
+      , Amazonka.status = status400
+      , Amazonka.headers = []
+      , Amazonka.code = "ValidationError"
+      , Amazonka.message = Nothing
+      , Amazonka.requestId = Nothing
+      }

--- a/test/Stackctl/Test/App.hs
+++ b/test/Stackctl/Test/App.hs
@@ -1,5 +1,8 @@
 module Stackctl.Test.App
-  ( TestAppT
+  ( TestApp
+  , testAppAwsScope
+  , testAppStackFilePath
+  , TestAppT
   , runTestAppT
 
     -- * Re-exports
@@ -16,12 +19,19 @@ import Blammo.Logging.Logger (newTestLogger)
 import Control.Lens ((?~))
 import Control.Monad.AWS
 import Control.Monad.AWS.ViaMock
+import Stackctl.AWS.Core (AccountId (..))
+import Stackctl.AWS.Scope
+import Stackctl.DirectoryOption
+import Stackctl.FilterOption
 import Test.Hspec (Spec, describe, example, it)
 import Test.Hspec.Expectations.Lifted
 
 data TestApp = TestApp
   { taLogger :: Logger
   , taMatchers :: Matchers
+  , taAwsScope :: AwsScope
+  , taFilterOption :: FilterOption
+  , taDirectoryOption :: DirectoryOption
   }
 
 instance HasLogger TestApp where
@@ -29,6 +39,15 @@ instance HasLogger TestApp where
 
 instance HasMatchers TestApp where
   matchersL = lens taMatchers $ \x y -> x {taMatchers = y}
+
+instance HasAwsScope TestApp where
+  awsScopeL = lens taAwsScope $ \x y -> x {taAwsScope = y}
+
+instance HasFilterOption TestApp where
+  filterOptionL = lens taFilterOption $ \x y -> x {taFilterOption = y}
+
+instance HasDirectoryOption TestApp where
+  directoryOptionL = lens taDirectoryOption $ \x y -> x {taDirectoryOption = y}
 
 newtype TestAppT m a = TestAppT
   { unTestAppT :: ReaderT TestApp (LoggingT m) a
@@ -53,5 +72,25 @@ runTestAppT f = do
     TestApp
       <$> newTestLogger defaultLogSettings
       <*> pure mempty
+      <*> pure testAppAwsScope
+      <*> pure defaultFilterOption
+      <*> pure defaultDirectoryOption
 
   runLoggerLoggingT app $ runReaderT (unTestAppT f) app
+
+testAppAwsScope :: AwsScope
+testAppAwsScope =
+  AwsScope
+    { awsAccountId = AccountId "0123456789"
+    , awsAccountName = "test"
+    , awsRegion = "us-east-1"
+    }
+
+-- | Gives a filepath relative to 'testAwsScope'
+testAppStackFilePath :: Text -> FilePath
+testAppStackFilePath base =
+  "stacks"
+    </> "0123456789.test"
+    </> "us-east-1"
+    </> unpack base
+    <.> "yaml"


### PR DESCRIPTION
When inferring removed stacks, we use use the fact that a specification
doesn't exist on disk to decide to remove the corresponding stack.
Checking for the specification on disk was not using
`STACKCTL_DIRECTORY`, so if one were set this would always report the
file as missing and could result in deleting a stack we should not.