### PR TITLE
Require Blammo-1.2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.6.1.1...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.6.1.2...main)
+
+## [v1.6.1.2](https://github.com/freckle/stackctl/compare/v1.6.1.1...v1.6.1.2)
+
+- Require Blammo-1.2.2.3
 
 ## [v1.6.1.1](https://github.com/freckle/stackctl/compare/v1.6.1.0...v1.6.1.1)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.6.1.1
+version: 1.6.1.2
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering
@@ -59,7 +59,7 @@ default-extensions:
 library:
   source-dirs: src
   dependencies:
-    - Blammo >= 1.1.2.1 # getColorsLogger, etc
+    - Blammo >= 1.1.2.3 # flushLogger bugfix
     - Glob
     - QuickCheck
     - aeson

--- a/stack-lts-20.4.yaml
+++ b/stack-lts-20.4.yaml
@@ -1,7 +1,7 @@
 resolver: lts-20.4
 
 extra-deps:
-  - Blammo-1.1.2.1
+  - Blammo-1.1.2.3
   - cfn-flip-0.1.0.3
   - unliftio-0.2.25.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-22.6
 
 extra-deps:
-  - Blammo-1.1.2.1
+  - Blammo-1.1.2.3
   - amazonka-mtl-0.1.1.0
   - cfn-flip-0.1.0.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: Blammo-1.1.2.1@sha256:b74d553fb3557bb10381b806bd34b8bad0b800883f02dfd1cc847f58db40958c,4084
+    hackage: Blammo-1.1.2.3@sha256:33112de7280df78009ced5e815907ef62f902b8165434f538ce584df6cd9e47a,4710
     pantry-tree:
-      sha256: bd28931f07beaaae8565a87d8c3b55d3e9ff5c332ae93dc32c1090a4c814e620
-      size: 1567
+      sha256: ec4524c3153eeb54a8554b3280e00011b21374e36df320733d0c35b8da0c9f23
+      size: 1651
   original:
-    hackage: Blammo-1.1.2.1
+    hackage: Blammo-1.1.2.3
 - completed:
     hackage: amazonka-mtl-0.1.1.0@sha256:90b45a950c0e398b0e48d1447766f331c2ac3d5a72e15be2bf0be3b3c56159c3,6572
     pantry-tree:

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -98,7 +98,7 @@ library
       TypeFamilies
   ghc-options: -fignore-optim-changes -fwrite-ide-info -Weverything -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-missing-import-lists -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module -Wno-unsafe -optP-Wno-nonportable-include-path
   build-depends:
-      Blammo >=1.1.2.1
+      Blammo >=1.1.2.3
     , Glob
     , QuickCheck
     , aeson


### PR DESCRIPTION
Works around a bug in `fast-logger` to ensure log messages are actually
flushed when `flushLogger` is used.
