### PR TITLE
Extend ParameterValue to support Numbers and Booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.6.1.2...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.7.0.0...main)
+
+## [v1.7.0.0](https://github.com/freckle/stackctl/compare/v1.6.1.2...v1.7.0.0)
+
+- Retain numeric parameter types, and add boolean parameter handling, in our own
+  yaml generation
+
+  This required changing `Generate` to use `ParametersYaml` instead of
+  `[Parameter]`, hence the major version bump.
 
 ## [v1.6.1.2](https://github.com/freckle/stackctl/compare/v1.6.1.1...v1.6.1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Retain numeric parameter types, and add boolean parameter handling, in our own
   yaml generation
 
-  This required changing `Generate` to use `ParametersYaml` instead of
-  `[Parameter]`, hence the major version bump.
+  This required changing the `Generate` to use `ParametersYaml` instead of
+  `[Parameter]`, and ultimately led us to removing it, hence the major version
+  bump.
 
 ## [v1.6.1.2](https://github.com/freckle/stackctl/compare/v1.6.1.1...v1.6.1.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.6.1.2
+version: 1.7.0.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/Spec/Capture.hs
+++ b/src/Stackctl/Spec/Capture.hs
@@ -13,6 +13,7 @@ import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption (HasDirectoryOption)
 import Stackctl.Spec.Generate
 import Stackctl.StackSpec
+import Stackctl.StackSpecYaml (parameterYaml, parametersYaml)
 import System.FilePath.Glob
 
 data CaptureOptions = CaptureOptions
@@ -103,7 +104,8 @@ runCapture CaptureOptions {..} = do
             { gDescription = stackDescription stack
             , gDepends = scoDepends
             , gActions = Nothing
-            , gParameters = parameters stack
+            , gParameters =
+                parametersYaml . mapMaybe parameterYaml <$> parameters stack
             , gCapabilities = capabilities stack
             , gTags = tags stack
             , gSpec = case path of

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -9,7 +9,6 @@ import Stackctl.Prelude
 
 import Stackctl.AWS
 import Stackctl.AWS.Scope
-import Stackctl.Action
 import Stackctl.Config (HasConfig)
 import Stackctl.DirectoryOption
 import Stackctl.Spec.Discover (buildSpecPath)

--- a/src/Stackctl/Spec/Generate.hs
+++ b/src/Stackctl/Spec/Generate.hs
@@ -22,7 +22,7 @@ data Generate = Generate
   { gDescription :: Maybe StackDescription
   , gDepends :: Maybe [StackName]
   , gActions :: Maybe [Action]
-  , gParameters :: Maybe [Parameter]
+  , gParameters :: Maybe ParametersYaml
   , gCapabilities :: Maybe [Capability]
   , gTags :: Maybe [Tag]
   , gSpec :: GenerateSpec
@@ -81,7 +81,7 @@ generate Generate {..} = do
         , ssyTemplate = templatePath
         , ssyDepends = gDepends
         , ssyActions = gActions
-        , ssyParameters = parametersYaml . mapMaybe parameterYaml <$> gParameters
+        , ssyParameters = gParameters
         , ssyCapabilities = gCapabilities
         , ssyTags = tagsYaml . map TagYaml <$> gTags
         }

--- a/src/Stackctl/StackSpecYaml.hs
+++ b/src/Stackctl/StackSpecYaml.hs
@@ -4,18 +4,24 @@
 -- Template: <path>
 --
 -- Depends:
--- - <string>
+--   - <string>
 --
 -- Parameters:
--- - ParameterKey: <string>
---   ParameterValue: <string>
+--   - ParameterKey: <string>
+--     ParameterValue: <string|number|boolean>
+--
+--   # Or
+--   <key>: <string|number|boolean>
 --
 -- Capabilities:
--- - <capability>
+--   - <capability>
 --
 -- Tags:
--- - Key: <string>
---   Value: <string>
+--   - Key: <string>
+--     Value: <string>
+--
+--   # Or
+--   <key>: <string>
 -- @
 module Stackctl.StackSpecYaml
   ( StackSpecYaml (..)

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.6.1.2
+version:        1.7.0.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.6.1.1
+version:        1.6.1.2
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/test/Stackctl/StackSpecYamlSpec.hs
+++ b/test/Stackctl/StackSpecYamlSpec.hs
@@ -80,28 +80,6 @@ spec = do
       param ^. parameter_parameterKey `shouldBe` Just "Pie"
       param ^. parameter_parameterValue `shouldBe` Just "3.14"
 
-    it "has informative errors" $ do
-      let Left ex =
-            Yaml.decodeEither' @StackSpecYaml
-              $ mconcat
-                [ "Template: foo.yaml\n"
-                , "Parameters:\n"
-                , "  - ParameterKey: Norway\n"
-                , "    ParameterValue: no\n"
-                ]
-
-      show ex
-        `shouldBe` "AesonException \"Error in $.Parameters[0].ParameterValue: Expected String or Number, got: Bool False\""
-
-    it "has informative errors in Object form" $ do
-      let Left ex =
-            Yaml.decodeEither' @StackSpecYaml
-              $ mconcat
-                ["Template: foo.yaml\n", "Parameters:\n", "  Norway: no\n"]
-
-      show ex
-        `shouldBe` "AesonException \"Error in $.Parameters.Norway: Expected String or Number, got: Bool False\""
-
     it "handles null Value" $ do
       StackSpecYaml {..} <-
         Yaml.decodeThrow


### PR DESCRIPTION
CloudFormation parameters in templates, can either be `String` or
`Number`. It's common convention to support "booleans" as well by using
`String` with `AllowedValues: [True, False]`. CloudFormation parameters
_when ultimately passed as part of a deploy_ must be strings. This
causes some edge cases, such as a stringified `Number` being passed at
deploy-time as `"3.0"`, instead of `"3"` and then failing.

For this reason, we had some special handling for values that parsed
from the actual spec yaml as a number. Even with this present, we still
captured the value as a `Text` internally (with special `".0"`-handling
pre-applied).

This causes user-facing confusion and complexity, since generation would
still always be at `Text`, even if the user had entered a numeric
literal in their spec yaml.

This commit changes that to retain the original type used in the
user-provided yaml, and only "cast" things to `Text` when necessary
(e.g. when need as a true Amazonka `Parameter`). This meant splitting
the `newtype` into an actual `data` type with cases for strings and
numbers. To this it adds a boolean case, encoding the `"True|False"`
convention described above.

Ultimately, this results in user-facing interfaces always using actual
string, number, or boolean types, and the necessary string casting
pushed further to the edges.

This changes the interface of `Generate` to deal in `ParametersYaml`
values instead of (Amazonka) `Parameter`s, so this will need a major
version bump.