### PR TITLE
Add withAssumedRole, deprecate assumeRole

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -2,7 +2,9 @@ restylers_version: dev
 restylers:
   - cabal-fmt:
       enabled: false
-  - fourmolu
+  - fourmolu:
+      image:
+        tag: v14
   - stylish-haskell:
       enabled: false
   - prettier-markdown:

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -4,7 +4,7 @@ restylers:
       enabled: false
   - fourmolu:
       image:
-        tag: v14
+        tag: v0.14.1.0
   - stylish-haskell:
       enabled: false
   - prettier-markdown:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.7.0.0...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.7.1.0...main)
+
+## [v1.7.1.0](https://github.com/freckle/stackctl/compare/v1.7.0.0...v1.7.1.0)
+
+- Add `withAssumedRole`, deprecate `assumeRole`
 
 ## [v1.7.0.0](https://github.com/freckle/stackctl/compare/v1.6.1.2...v1.7.0.0)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.7.0.0
+version: 1.7.1.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/src/Stackctl/AWS/Core.hs
+++ b/src/Stackctl/AWS/Core.hs
@@ -95,7 +95,7 @@ simple req post = do
 -- | Use 'withAssumedRole' instead
 --
 -- This function is like 'withAssumedRole' except it doesn't spawn a background
--- thread to keep credentials refreshed. You make encounter expired credentials
+-- thread to keep credentials refreshed. You may encounter expired credentials
 -- if the block used under 'assumeRole' goes for long enough.
 assumeRole
   :: (MonadIO m, MonadAWS m)

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.7.0.0
+version:        1.7.1.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues


### PR DESCRIPTION
`assumeRole` does not spawn a background thread to refresh credentials.
This means that if the block goes on long enough, expired credentials
errors will start happening.

`withAssumedRole` addresses this. I chose to make a new function under a
different name for two reasons:

1. The fixed function incurs a `MonadUnliftIO` constraint. Users could
   stay on the deprecated function if they're not able to quickly
   organize things to satisfy this constraint.
2. The naming better matches the analogous Amazonka function[^1].

[^1]: https://hackage.haskell.org/package/amazonka-2.0/docs/Amazonka-Auth-STS.html#v:fromAssumedRole
