### PR TITLE
Cancel UpdateStack operations on Ctl-C

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -11,6 +11,7 @@
 - ignore: {name: "Use join"}  # this often leads to cryptic code when do notation is easier to read
 - ignore: {name: "Redundant ^."}  # commonly broken by esqueleto
 - ignore: {name: "Use ++"}  # less readable for commandline option lists
+- ignore: {name: "Functor law"} # too aggressive
 
 # Custom Warnings
 - warn: {lhs: mapM, rhs: traverse}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.7.1.0...main)
+## [_Unreleased_](https://github.com/freckle/stackctl/compare/v1.7.2.0...main)
+
+## [v1.7.2.0](https://github.com/freckle/stackctl/compare/v1.7.1.0...v1.7.2.0)
+
+- Automatically cancel any ongoing update-stack operations on `^C`
 
 ## [v1.7.1.0](https://github.com/freckle/stackctl/compare/v1.7.0.0...v1.7.1.0)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stackctl
-version: 1.7.1.0
+version: 1.7.2.0
 github: freckle/stackctl
 license: MIT
 author: Freckle Engineering

--- a/package.yaml
+++ b/package.yaml
@@ -95,6 +95,7 @@ library:
     - time
     - transformers
     - typed-process
+    - unix
     - unliftio >= 0.2.25.0 # UnliftIO.Exception.Lens
     - unordered-containers
     - uuid

--- a/src/Stackctl/CancelHandler.hs
+++ b/src/Stackctl/CancelHandler.hs
@@ -9,11 +9,11 @@ import Stackctl.Prelude
 
 import System.Posix.Signals
 
--- | Install a 'keyboardSignal handler, run an action, then remove it
+-- | Install a 'keyboardSignal' handler, run an action, then remove it
 with :: MonadUnliftIO m => m a -> m b -> m b
 with f = bracket (install f) (const remove) . const
 
--- | Install a 'keyboardSignal handler that runs the given action once
+-- | Install a 'keyboardSignal' handler that runs the given action once
 install :: MonadUnliftIO m => m a -> m ()
 install f = do
   withRunInIO $ \runInIO -> do
@@ -22,11 +22,11 @@ install f = do
           runInIO f
     void $ installHandler keyboardSignal handler Nothing
 
--- | Remove the current handler for 'keyboardSignal (i.e. install 'Default')
+-- | Remove the current handler for 'keyboardSignal' (i.e. install 'Default')
 remove :: MonadIO m => m ()
 remove = liftIO $ void $ installHandler keyboardSignal Default Nothing
 
--- | Trigger the installed 'keyboardSignal handler
+-- | Trigger the installed 'keyboardSignal' handler
 --
 -- This is used by our test suite.
 trigger :: MonadIO m => m ()

--- a/src/Stackctl/CancelHandler.hs
+++ b/src/Stackctl/CancelHandler.hs
@@ -11,7 +11,7 @@ import System.Posix.Signals
 
 -- | Install a 'keyboardSignal' handler, run an action, then remove it
 with :: MonadUnliftIO m => m a -> m b -> m b
-with f = bracket (install f) (const remove) . const
+with f = bracket_ (install f) remove
 
 -- | Install a 'keyboardSignal' handler that runs the given action once
 install :: MonadUnliftIO m => m a -> m ()

--- a/src/Stackctl/CancelHandler.hs
+++ b/src/Stackctl/CancelHandler.hs
@@ -1,0 +1,33 @@
+module Stackctl.CancelHandler
+  ( with
+  , install
+  , remove
+  , trigger
+  ) where
+
+import Stackctl.Prelude
+
+import System.Posix.Signals
+
+-- | Install a 'keyboardSignal handler, run an action, then remove it
+with :: MonadUnliftIO m => m a -> m b -> m b
+with f = bracket (install f) (const remove) . const
+
+-- | Install a 'keyboardSignal handler that runs the given action once
+install :: MonadUnliftIO m => m a -> m ()
+install f = do
+  withRunInIO $ \runInIO -> do
+    let handler = Catch $ void $ do
+          remove -- so next Ctl-C will truly cancel
+          runInIO f
+    void $ installHandler keyboardSignal handler Nothing
+
+-- | Remove the current handler for 'keyboardSignal (i.e. install 'Default')
+remove :: MonadIO m => m ()
+remove = liftIO $ void $ installHandler keyboardSignal Default Nothing
+
+-- | Trigger the installed 'keyboardSignal handler
+--
+-- This is used by our test suite.
+trigger :: MonadIO m => m ()
+trigger = liftIO $ raiseSignal keyboardSignal

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -35,6 +35,7 @@ library
       Stackctl.AWS.Orphans
       Stackctl.AWS.Scope
       Stackctl.AWS.STS
+      Stackctl.CancelHandler
       Stackctl.CLI
       Stackctl.ColorOption
       Stackctl.Colors
@@ -135,6 +136,7 @@ library
     , time
     , transformers
     , typed-process
+    , unix
     , unliftio >=0.2.25.0
     , unordered-containers
     , uuid
@@ -187,6 +189,7 @@ test-suite spec
       Stackctl.AWS.EC2Spec
       Stackctl.AWS.LambdaSpec
       Stackctl.AWS.ScopeSpec
+      Stackctl.CancelHandlerSpec
       Stackctl.Config.RequiredVersionSpec
       Stackctl.ConfigSpec
       Stackctl.FilterOptionSpec

--- a/stackctl.cabal
+++ b/stackctl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           stackctl
-version:        1.7.1.0
+version:        1.7.2.0
 description:    Please see <https://github.com/freckle/stackctl#readme>
 homepage:       https://github.com/freckle/stackctl#readme
 bug-reports:    https://github.com/freckle/stackctl/issues

--- a/test/Stackctl/CancelHandlerSpec.hs
+++ b/test/Stackctl/CancelHandlerSpec.hs
@@ -1,0 +1,19 @@
+module Stackctl.CancelHandlerSpec
+  ( spec
+  ) where
+
+import Stackctl.Prelude
+
+import qualified Stackctl.CancelHandler as CancelHandler
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "with" $ do
+    fit "installs a handler for the duration of a block" $ example $ do
+      done <- newEmptyMVar
+
+      CancelHandler.install $ putMVar done ()
+      CancelHandler.trigger
+
+      takeMVar done `shouldReturn` ()

--- a/test/Stackctl/Spec/Changes/FormatSpec.hs
+++ b/test/Stackctl/Spec/Changes/FormatSpec.hs
@@ -5,9 +5,8 @@ where
 
 import Stackctl.Prelude
 
-import Amazonka.CloudFormation.Types (ChangeSetType (..))
 import Data.Aeson
-import Stackctl.AWS.CloudFormation (changeSetFromResponse)
+import Stackctl.AWS.CloudFormation (ChangeSetType (..), changeSetFromResponse)
 import Stackctl.Colors
 import Stackctl.Spec.Changes.Format
 import System.FilePath ((-<.>))

--- a/test/Stackctl/Spec/Changes/FormatSpec.hs
+++ b/test/Stackctl/Spec/Changes/FormatSpec.hs
@@ -5,6 +5,7 @@ where
 
 import Stackctl.Prelude
 
+import Amazonka.CloudFormation.Types (ChangeSetType (..))
 import Data.Aeson
 import Stackctl.AWS.CloudFormation (changeSetFromResponse)
 import Stackctl.Colors
@@ -28,7 +29,7 @@ formatChangeSetGolden :: FilePath -> Format -> IO (Golden Text)
 formatChangeSetGolden path fmt = do
   actual <-
     formatChangeSet noColors OmitFull "some-stack" fmt
-      . (changeSetFromResponse <=< decodeStrict)
+      . (changeSetFromResponse ChangeSetType_UPDATE <=< decodeStrict)
       . encodeUtf8
       <$> readFileUtf8 path
 


### PR DESCRIPTION
We install a `^C` handler before starting the deploy-change-set operation. If we're
doing an update (not a create), we can cancel the update on `^C`. The code will then
proceed waiting for the rollback events and ultimately get a fail status:

![](https://files.pbrisbin.com/screenshots/screenshot.3323976.png)

The handler is removed when invoked, so that `^C` again will abort this and
actually just exit.

This will kick in (and be particularly useful) on GitHub Actions, where build cancellation
sends `INT` to processes. Now if builds are cancelled there (due to being redundant
or manually) corresponding stack updates will be rolled back too.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207422437280305