### PR TITLE
fix(release): don't reference removed resolver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,4 +77,3 @@ jobs:
           FORCE_COLOR: 1
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           HACKAGE_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
-          STACK_YAML: stack-lts-20.4.yaml


### PR DESCRIPTION
This broke release of v1.7.3.1[^1]. Going back and redoing a partial
release is annoying, so I'm just calling this commit a `fix` so we
release v1.7.3.2.

[^1]: https://github.com/freckle/stackctl/actions/runs/13443053932/job/37563302281#step:5:141
