### PR TITLE
fix: use released version of semantic-release-stack-upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           dry_run: true
           extra_plugins: |
-            git+https://github.com/pbrisbin/semantic-release-stack-upload.git
+            semantic-release-stack-upload
         env:
           FORCE_COLOR: 1
           PREPARE_IN_VERIFY: 1
@@ -72,7 +72,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
-            git+https://github.com/pbrisbin/semantic-release-stack-upload.git
+            semantic-release-stack-upload
         env:
           FORCE_COLOR: 1
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
I figured out how to publish to npm, so no need for the git reference. I called it `fix:` just to trigger it and ensure it worked.